### PR TITLE
fix(onboarding): unblock first-run loading

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -13060,6 +13060,7 @@ export async function ensureFullSettingsLoaded() {
 }
 
 export async function getSettings(options = {}) {
+    let shouldPersistFirstRunCompletion = false;
     const useBootstrap = options?.bootstrap === true;
     const data = options?.payload ?? await fetchSettingsPayload(useBootstrap ? '/api/settings/bootstrap' : '/api/settings/get');
 
@@ -13170,15 +13171,22 @@ export async function getSettings(options = {}) {
         firstRun = !!settings.firstRun;
 
         if (firstRun) {
-            await initLoaderHandle?.hide();
+            if (isLoaderVisible()) {
+                await hideLoader();
+            }
             await doOnboarding(user_avatar);
             firstRun = false;
+            shouldPersistFirstRunCompletion = true;
         }
     }
     await validateDisabledSamplers();
     rememberSettingsSnapshot(buildSettingsPayload());
     settingsReady = true;
     await eventSource.emit(event_types.SETTINGS_LOADED);
+
+    if (shouldPersistFirstRunCompletion) {
+        await saveSettings(0, { directSave: true });
+    }
 
     if (useBootstrap) {
         void warmPreloadFullSettings();

--- a/tests/jest.config.json
+++ b/tests/jest.config.json
@@ -1,5 +1,8 @@
 {
     "verbose": true,
     "transform": {},
+    "setupFiles": [
+        "./jest.setup.js"
+    ],
     "testEnvironment": "node"
 }

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -1,0 +1,13 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { getConfigFilePath, reloadConfigCache, setConfigFilePath } from '../src/util.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const configPath = path.resolve(__dirname, '../config.yaml');
+
+if (!getConfigFilePath()) {
+    setConfigFilePath(configPath);
+    reloadConfigCache();
+}


### PR DESCRIPTION
前端初始化在首轮 onboarding 分支里报错了：ReferenceError: initLoaderHandle is not defined
报错点在 public/script.js (line 13173)
这会让 getSettings() 中断，preloader 不会被移除，loader 不会隐藏，页面看起来一直在加载
这个问题只要 settings.firstRun === true 就会触发

Fix：
在 public/script.js (line 13062) 做了两处修复：
把失效的 initLoaderHandle?.hide() 改成当前真实可用的 loader API：
在 public/script.js (line 13173) 先判断 isLoaderVisible()，再 await hideLoader()
增加显式的 first-run 持久化：
在 public/script.js (line 13187) 完成 onboarding 后，await saveSettings(0, { directSave: true })