### PR TITLE
fix(mobile): improve touch spacing for worldbook and preset controls

### DIFF
--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -260,9 +260,28 @@
         padding-bottom: 5px;
     }
 
+    /* On mobile, float the multi-select checkbox out of the flex row so expand/toggle have room */
+    .world_entry .wi-card-entry {
+        position: relative;
+    }
+
+    .world_entry_select_label {
+        position: absolute;
+        top: 8px;
+        left: 28px;
+        z-index: 1;
+    }
+
     #worldInfoScanningCheckboxes {
         flex-flow: row;
         flex-wrap: wrap;
+    }
+
+    /* Prompt preset controls (mobile): spread first 3 icons, keep toggle position unchanged */
+    #completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt .prompt_manager_prompt_controls > span.prompt-manager-detach-action,
+    #completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt .prompt_manager_prompt_controls > span.prompt-manager-edit-action,
+    #completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt .prompt_manager_prompt_controls > span.prompt-manager-plugin-extra-action {
+        margin-right: 0.6em;
     }
 
     body {

--- a/public/scripts/templates/wandMenu.html
+++ b/public/scripts/templates/wandMenu.html
@@ -14,4 +14,5 @@
     <div id="dice_wand_container" class="extension_container"></div>
     <div id="objective_wand_container" class="extension_container"></div>
     <div id="translate_wand_container" class="extension_container"></div>
+    <div id="sp_wand_container" class="extension_container"></div>
 </div>


### PR DESCRIPTION
Adjust mobile-only layout to reduce mis-taps in WI entries and prompt preset action icons, and add wand container hook for schedule planner entry.

<!-- Put X in the box below to confirm -->

## Checklist:

- [ ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
