### PR TITLE
fix(移动端): 优化世界书条目在窄屏下的布局

### DIFF
--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -260,16 +260,84 @@
         padding-bottom: 5px;
     }
 
-    /* On mobile, float the multi-select checkbox out of the flex row so expand/toggle have room */
+    /* WI entry: column layout, icons row on top, title row below */
     .world_entry .wi-card-entry {
-        position: relative;
+        position: static;
+    }
+
+    .world_entry .inline-drawer-header {
+        align-items: flex-start;
+    }
+
+    .world_entry .inline-drawer-header .drag-handle {
+        align-self: flex-start;
+        padding-top: 2px;
     }
 
     .world_entry_select_label {
-        position: absolute;
-        top: 8px;
-        left: 28px;
-        z-index: 1;
+        position: static;
+        flex-shrink: 0;
+        transform: scale(0.85);
+        opacity: 0.6;
+    }
+
+    .world_entry_thin_controls {
+        flex-direction: column;
+        align-items: stretch;
+        align-self: flex-start;
+        justify-content: flex-start;
+        gap: 4px;
+        width: 100%;
+    }
+
+    .wi-header-icons-row {
+        flex-shrink: 0;
+        align-items: center;
+        padding: 4px 0 2px;
+    }
+
+    .WIEntryTitleAndStatus {
+        width: 100%;
+        min-width: 0;
+    }
+
+    .WIEntryTitleAndStatus .flex-container.flex1 {
+        min-width: 0;
+        flex: 1;
+    }
+
+    .WIEntryTitleAndStatus select[name="entryStateSelector"] {
+        flex-shrink: 0;
+        max-width: 3em;
+    }
+
+    /* The wrapper div around WIEntryTitleAndStatus */
+    .world_entry_thin_controls > .flex-container {
+        flex-shrink: 0;
+        align-items: center;
+        width: 100%;
+    }
+
+    /* Override world-info.css flex: 1 1 18rem which stretches this div in column layout */
+    .world_entry .inline-drawer-header > .world_entry_thin_controls > .flex-container {
+        flex: 0 0 auto !important;
+        min-width: 0;
+        width: 100%;
+    }
+
+    /* Hide action buttons and metadata controls when collapsed; show when expanded */
+    .world_entry .move_entry_button,
+    .world_entry .duplicate_entry_button,
+    .world_entry .delete_entry_button,
+    .world_entry .WIEntryHeaderControls {
+        display: none !important;
+    }
+
+    .world_entry .inline-drawer:has(.inline-drawer-icon.up) .move_entry_button,
+    .world_entry .inline-drawer:has(.inline-drawer-icon.up) .duplicate_entry_button,
+    .world_entry .inline-drawer:has(.inline-drawer-icon.up) .delete_entry_button,
+    .world_entry .inline-drawer:has(.inline-drawer-icon.up) .WIEntryHeaderControls {
+        display: flex !important;
     }
 
     #worldInfoScanningCheckboxes {
@@ -360,11 +428,6 @@
     .wi-settings {
         flex-direction: column;
         gap: 5px !important;
-    }
-
-    .WIEntryTitleAndStatus,
-    .WIEntryHeaderControls {
-        width: 100%;
     }
 
     #WIEntryHeaderTitlesPC {

--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -257,87 +257,124 @@
     }
 
     .world_entry .inline-drawer-toggle {
-        padding-bottom: 5px;
+        align-self: center;
+        padding-bottom: 0;
     }
 
-    /* WI entry: column layout, icons row on top, title row below */
+    /* WI entry: fix title being squeezed on narrow screens, CSS-only, no HTML changes */
     .world_entry .wi-card-entry {
         position: static;
-    }
-
-    .world_entry .inline-drawer-header {
-        align-items: flex-start;
-    }
-
-    .world_entry .inline-drawer-header .drag-handle {
-        align-self: flex-start;
-        padding-top: 2px;
     }
 
     .world_entry_select_label {
         position: static;
         flex-shrink: 0;
-        transform: scale(0.85);
-        opacity: 0.6;
+        order: 99;
     }
 
-    .world_entry_thin_controls {
-        flex-direction: column;
-        align-items: stretch;
-        align-self: flex-start;
-        justify-content: flex-start;
-        gap: 4px;
-        width: 100%;
-    }
-
-    .wi-header-icons-row {
-        flex-shrink: 0;
-        align-items: center;
-        padding: 4px 0 2px;
-    }
-
+    /* Let WIEntryTitleAndStatus shrink properly */
     .WIEntryTitleAndStatus {
-        width: 100%;
         min-width: 0;
+        flex: 1 1 0;
     }
 
     .WIEntryTitleAndStatus .flex-container.flex1 {
         min-width: 0;
-        flex: 1;
+        flex: 1 1 0;
+    }
+
+    .WIEntryTitleAndStatus .flex-container.flex1 textarea {
+        min-width: 0;
     }
 
     .WIEntryTitleAndStatus select[name="entryStateSelector"] {
         flex-shrink: 0;
-        max-width: 3em;
     }
 
-    /* The wrapper div around WIEntryTitleAndStatus */
-    .world_entry_thin_controls > .flex-container {
-        flex-shrink: 0;
-        align-items: center;
-        width: 100%;
-    }
-
-    /* Override world-info.css flex: 1 1 18rem which stretches this div in column layout */
+    /* Override world-info.css flex: 1 1 18rem on the wrapper div */
     .world_entry .inline-drawer-header > .world_entry_thin_controls > .flex-container {
-        flex: 0 0 auto !important;
+        flex: 1 1 0 !important;
         min-width: 0;
-        width: 100%;
     }
 
-    /* Hide action buttons and metadata controls when collapsed; show when expanded */
+    /* Hide action buttons when collapsed; show when expanded */
     .world_entry .move_entry_button,
     .world_entry .duplicate_entry_button,
     .world_entry .delete_entry_button,
-    .world_entry .WIEntryHeaderControls {
+    .world_entry .trace_activation_button,
+    .world_entry .WIEntryHeaderControls,
+    .world_entry select[name="entryStateSelector"] {
         display: none !important;
     }
 
+    /* ── 展开状态布局 ──────────────────────────────────────────── */
+    .world_entry .inline-drawer:has(.inline-drawer-icon.up) .inline-drawer-header {
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0 !important;
+        padding: 0 !important;
+    }
+
+    /* 打通 thin_controls 和中间 flex-container，让子元素参与 header 的 flex 流 */
+    .world_entry .inline-drawer:has(.inline-drawer-icon.up) .world_entry_thin_controls,
+    .world_entry .inline-drawer:has(.inline-drawer-icon.up) .world_entry_thin_controls > .flex-container {
+        display: contents !important;
+    }
+
+    /* 行1：▼ 👁 ✓ — 三个平分整行 */
+    .world_entry .inline-drawer:has(.inline-drawer-icon.up) .drag-handle {
+        display: none !important;
+    }
+    .world_entry .inline-drawer:has(.inline-drawer-icon.up) .inline-drawer-toggle {
+        order: 1; flex: 0 0 calc(100% / 3);
+        display: flex; align-items: center; justify-content: center;
+    }
+    .world_entry .inline-drawer:has(.inline-drawer-icon.up) .killSwitch {
+        order: 2; flex: 0 0 calc(100% / 3);
+        display: flex; align-items: center; justify-content: center;
+    }
+    .world_entry .inline-drawer:has(.inline-drawer-icon.up) .world_entry_select_label {
+        order: 3; flex: 0 0 calc(100% / 3); margin-left: 0;
+        display: flex; align-items: center; justify-content: center;
+    }
+
+    /* 行2：标题 + 🔵▼，order:10 + 100% 宽度触发换行 */
+    .world_entry .inline-drawer:has(.inline-drawer-icon.up) .WIEntryTitleAndStatus {
+        order: 10;
+        flex: 1 1 100%;
+        min-width: 0;
+    }
+    .world_entry .inline-drawer:has(.inline-drawer-icon.up) select[name="entryStateSelector"] {
+        display: flex !important;
+        order: 10;
+        flex: 0 0 auto;
+    }
+
+    /* 行3：WIEntryHeaderControls 作为真实容器撑满整行，4个按钮无法挤入 */
+    .world_entry .inline-drawer:has(.inline-drawer-icon.up) .WIEntryHeaderControls {
+        display: flex !important;
+        order: 20;
+        flex: 1 1 100%;
+        flex-wrap: nowrap;
+        align-items: center;
+        gap: 4px;
+    }
+
+    /* 输入框撑满可用空间 */
+    .world_entry .inline-drawer:has(.inline-drawer-icon.up) .WIEntryHeaderControls input.wideMax100px {
+        max-width: unset;
+        flex: 1 1 0;
+    }
+
+    /* 行4：4个按钮，order:30 */
     .world_entry .inline-drawer:has(.inline-drawer-icon.up) .move_entry_button,
     .world_entry .inline-drawer:has(.inline-drawer-icon.up) .duplicate_entry_button,
     .world_entry .inline-drawer:has(.inline-drawer-icon.up) .delete_entry_button,
-    .world_entry .inline-drawer:has(.inline-drawer-icon.up) .WIEntryHeaderControls {
+    .world_entry .inline-drawer:has(.inline-drawer-icon.up) .trace_activation_button {
         display: flex !important;
+        order: 30;
+        flex: 0 0 auto;
+        align-self: center;
     }
 
     #worldInfoScanningCheckboxes {

--- a/public/index.html
+++ b/public/index.html
@@ -7303,13 +7303,15 @@
                     <div class="inline-drawer wide100p">
                         <div class="inline-drawer-header gap5px padding0">
                             <span class="drag-handle">&#9776;</span>
-                            <label class="checkbox_label world_entry_select_label" title="Select this entry for bulk actions" data-i18n="[title]Select this entry for bulk actions">
-                                <input type="checkbox" class="world_entry_select">
-                                <span class="fa-solid fa-check"></span>
-                            </label>
                             <div class="gap5px world_entry_thin_controls wide100p alignitemscenter">
-                                <div class="inline-drawer-toggle fa-fw fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
-                                <div class="fa-solid fa-toggle-on killSwitch" name="entryKillSwitch" data-i18n="[title]Toggle entry's active state." title="Toggle entry's active state."></div>
+                                <div class="wi-header-icons-row flex-container alignitemscenter gap5px">
+                                    <div class="inline-drawer-toggle fa-fw fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
+                                    <div class="fa-solid fa-toggle-on killSwitch" name="entryKillSwitch" data-i18n="[title]Toggle entry's active state." title="Toggle entry's active state."></div>
+                                    <label class="checkbox_label world_entry_select_label" title="Select this entry for bulk actions" data-i18n="[title]Select this entry for bulk actions">
+                                        <input type="checkbox" class="world_entry_select">
+                                        <span class="fa-solid fa-check"></span>
+                                    </label>
+                                </div>
                                 <div class="flex-container alignitemscenter wide100p">
                                     <div class="WIEntryTitleAndStatus flex-container flex1 alignitemscenter">
                                         <div class="flex-container flex1">

--- a/public/index.html
+++ b/public/index.html
@@ -7303,15 +7303,13 @@
                     <div class="inline-drawer wide100p">
                         <div class="inline-drawer-header gap5px padding0">
                             <span class="drag-handle">&#9776;</span>
+                            <label class="checkbox_label world_entry_select_label" title="Select this entry for bulk actions" data-i18n="[title]Select this entry for bulk actions">
+                                <input type="checkbox" class="world_entry_select">
+                                <span class="fa-solid fa-check"></span>
+                            </label>
                             <div class="gap5px world_entry_thin_controls wide100p alignitemscenter">
-                                <div class="wi-header-icons-row flex-container alignitemscenter gap5px">
-                                    <div class="inline-drawer-toggle fa-fw fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
-                                    <div class="fa-solid fa-toggle-on killSwitch" name="entryKillSwitch" data-i18n="[title]Toggle entry's active state." title="Toggle entry's active state."></div>
-                                    <label class="checkbox_label world_entry_select_label" title="Select this entry for bulk actions" data-i18n="[title]Select this entry for bulk actions">
-                                        <input type="checkbox" class="world_entry_select">
-                                        <span class="fa-solid fa-check"></span>
-                                    </label>
-                                </div>
+                                <div class="inline-drawer-toggle fa-fw fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
+                                <div class="fa-solid fa-toggle-on killSwitch" name="entryKillSwitch" data-i18n="[title]Toggle entry's active state." title="Toggle entry's active state."></div>
                                 <div class="flex-container alignitemscenter wide100p">
                                     <div class="WIEntryTitleAndStatus flex-container flex1 alignitemscenter">
                                         <div class="flex-container flex1">


### PR DESCRIPTION
- 将图标行（展开/开关/多选）和标题行拆分为独立两行，解决极窄屏下标题被挤压的问题
- 折叠状态隐藏操作按钮（移动/复制/删除）和元数据控件，展开后才显示，减少 header 拥挤
- 多选框移入图标行末尾，缩小视觉权重

<!-- Put X in the box below to confirm -->

## Checklist:

- [ ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
