### PR TITLE
将启动时版本更新检查改为异步后台执行，解决连不上github时启动一直卡加载界面的问题

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1373,30 +1373,47 @@ async function getClientVersion() {
     }
 }
 
-function maybeNotifyLukerUpdate(versionData) {
-    if (!versionData || versionData.isLatest !== false) {
+async function doLukerUpdateCheck(versionData) {
+    if (!versionData) {
         return;
     }
 
-    if (versionData.isDocker === true) {
-        if (lukerUpdatePromptShown) {
+    try {
+        const response = await fetch('/api/system/update-check', { 
+            method: 'POST',
+            headers: getRequestHeaders(),
+        });
+        if (!response.ok) return;
+        const updateData = await response.json();
+
+        if (updateData.isLatest !== false) {
             return;
         }
-        lukerUpdatePromptShown = true;
-        toastr.info(
-            t`A Luker update is available for this Docker deployment. Pull the latest image and recreate the container to update.`,
-            t`Update Available`,
-            {
-                timeOut: 0,
-                extendedTimeOut: 0,
-                closeButton: true,
-                preventDuplicates: true,
-            },
-        );
-        return;
-    }
 
-    void showLukerUpdatePrompt(versionData);
+        const combinedData = { ...versionData, ...updateData };
+
+        if (combinedData.isDocker === true) {
+            if (lukerUpdatePromptShown) {
+                return;
+            }
+            lukerUpdatePromptShown = true;
+            toastr.info(
+                t`A Luker update is available for this Docker deployment. Pull the latest image and recreate the container to update.`,
+                t`Update Available`,
+                {
+                    timeOut: 0,
+                    extendedTimeOut: 0,
+                    closeButton: true,
+                    preventDuplicates: true,
+                },
+            );
+            return;
+        }
+
+        void showLukerUpdatePrompt(combinedData);
+    } catch (err) {
+        console.error('Failed to check for Luker updates in background', err);
+    }
 }
 
 let lukerUpdatePromptShown = false;
@@ -1954,7 +1971,7 @@ async function firstLoadInit() {
     }
     await readSecretState();
     await initLocales();
-    maybeNotifyLukerUpdate(clientVersionData);
+    setTimeout(() => doLukerUpdateCheck(clientVersionData), 1);
     initChatUtilities();
     initDefaultSlashCommands();
     registerReasoningSlashCommands();

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -107,6 +107,7 @@ import hostWhitelistMiddleware from './middleware/hostWhitelist.js';
 import userCssMiddleware from './middleware/userCss.js';
 import {
     getVersion,
+    checkRemoteVersion,
     color,
     removeColorFormatting,
     getSeparator,
@@ -520,6 +521,11 @@ app.get('/version', async function (_, response) {
     response.send(data);
 });
 
+app.post('/api/system/update-check', async function (_, response) {
+    const data = await checkRemoteVersion();
+    response.send(data);
+});
+
 setupPrivateEndpoints(app);
 
 /**
@@ -536,10 +542,12 @@ async function preSetupTasks() {
         const date = new Date(version.commitDate);
         const localDate = date.toLocaleString('en-US', { timeZoneName: 'short' });
         console.log(`Running '${version.gitBranch}' (${version.gitRevision}) - ${localDate}`);
-        if (!version.isLatest && ['staging', 'release'].includes(version.gitBranch)) {
-            console.log('INFO: A newer tagged Luker version is available.');
-            console.log('      Pull latest tags/changes to update.');
-        }
+        checkRemoteVersion().then((remoteData) => {
+            if (!remoteData.isLatest && ['staging', 'release'].includes(version.gitBranch)) {
+                console.log('INFO: A newer tagged Luker version is available.');
+                console.log('      Pull latest tags/changes to update.');
+            }
+        });
     }
     console.log();
 

--- a/src/util.js
+++ b/src/util.js
@@ -153,6 +153,31 @@ export async function getVersion() {
             } catch {
                 // No local git metadata (e.g. Docker image without .git). Continue silently.
             }
+            // Remote check is now handled via checkRemoteVersion
+        }
+    } catch {
+        // suppress exception
+    }
+
+    const stCompatVersion = String(process.env.LUKER_ST_COMPAT_VERSION || '1.18.0').trim() || '1.18.0';
+    const agent = `Luker:${pkgVersion}:Cohee#1207`;
+    const compatAgent = `Luker:${stCompatVersion}:Cohee#1207`;
+    const isDockerRuntime = isDocker();
+    return { agent, compatAgent, stCompatVersion, pkgVersion, gitRevision, gitBranch, commitDate: commitDate?.trim() ?? null, isLatest, isDocker: isDockerRuntime };
+}
+
+/**
+ * Checks GitHub for the latest release tag and determines if an update is available.
+ * @returns {Promise<{isLatest: boolean}>} Update info
+ */
+export async function checkRemoteVersion() {
+    let isLatest = true;
+    try {
+        const require = createRequire(import.meta.url);
+        const pkgJson = require(path.join(serverDirectory, './package.json'));
+        const pkgVersion = pkgJson.version;
+        if (commandExistsSync('git')) {
+            const git = simpleGit({ baseDir: serverDirectory });
             let remoteTags = '';
             try {
                 remoteTags = await git.listRemote(['--tags', 'origin']);
@@ -174,12 +199,7 @@ export async function getVersion() {
     } catch {
         // suppress exception
     }
-
-    const stCompatVersion = String(process.env.LUKER_ST_COMPAT_VERSION || '1.18.0').trim() || '1.18.0';
-    const agent = `Luker:${pkgVersion}:Cohee#1207`;
-    const compatAgent = `Luker:${stCompatVersion}:Cohee#1207`;
-    const isDockerRuntime = isDocker();
-    return { agent, compatAgent, stCompatVersion, pkgVersion, gitRevision, gitBranch, commitDate: commitDate?.trim() ?? null, isLatest, isDocker: isDockerRuntime };
+    return { isLatest };
 }
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -130,15 +130,14 @@ export function getBasicAuthHeader(auth) {
 /**
  * Returns the version of the running instance. Get the version from package.json and git metadata.
  * Also returns the agent string for the Horde API.
- * isLatest is computed by comparing package version against the highest remote git tag version.
- * @returns {Promise<{agent: string, compatAgent: string, stCompatVersion: string, pkgVersion: string, gitRevision: string | null, gitBranch: string | null, commitDate: string | null, isLatest: boolean, isDocker: boolean}>} Version info object
+ * Performs only local reads; use checkRemoteVersion() for the upstream tag comparison.
+ * @returns {Promise<{agent: string, compatAgent: string, stCompatVersion: string, pkgVersion: string, gitRevision: string | null, gitBranch: string | null, commitDate: string | null, isDocker: boolean}>} Version info object
  */
 export async function getVersion() {
     let pkgVersion = 'UNKNOWN';
     let gitRevision = null;
     let gitBranch = null;
     let commitDate = null;
-    let isLatest = true;
 
     try {
         const require = createRequire(import.meta.url);
@@ -153,7 +152,6 @@ export async function getVersion() {
             } catch {
                 // No local git metadata (e.g. Docker image without .git). Continue silently.
             }
-            // Remote check is now handled via checkRemoteVersion
         }
     } catch {
         // suppress exception
@@ -163,7 +161,7 @@ export async function getVersion() {
     const agent = `Luker:${pkgVersion}:Cohee#1207`;
     const compatAgent = `Luker:${stCompatVersion}:Cohee#1207`;
     const isDockerRuntime = isDocker();
-    return { agent, compatAgent, stCompatVersion, pkgVersion, gitRevision, gitBranch, commitDate: commitDate?.trim() ?? null, isLatest, isDocker: isDockerRuntime };
+    return { agent, compatAgent, stCompatVersion, pkgVersion, gitRevision, gitBranch, commitDate: commitDate?.trim() ?? null, isDocker: isDockerRuntime };
 }
 
 /**


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

问题描述： 在国内网络环境下，原代码在启动服务器和前端加载页面时，会因为同步执行 git ls-remote 去请求 GitHub 获取最新标签而遭遇长时间的阻塞，导致终端启动缓慢以及浏览器页面一直卡在转圈动画，无法进入。

修改内容：

将原来 getVersion() 中的远程 git ls-remote 检查剥离到了独立的 checkRemoteVersion() 函数和专用的 /api/system/update-check 后端接口中。现在的 /version 接口只做本地数据的读取，能够 0 延迟秒开。
前端借鉴了扩展模块更新（Extension Updater）的机制，在启动完毕后利用 setTimeout 在后台悄悄请求更新状态。当拿到结果后如果有更新，会在当次加载直接弹窗提示。
后端 preSetupTasks 启动阶段控制台的 INFO: A newer tagged Luker version is available. 提示同样改为 Promise 异步打印，保留了原有功能。