### PR TITLE
feat(memory-graph): expose inline-UI API surface for external frontends

### DIFF
--- a/docs/development/extension-api/memory-graph.md
+++ b/docs/development/extension-api/memory-graph.md
@@ -113,6 +113,70 @@ await mg.removeCharacterAdvancedOverride(ctx, avatar);
 
 These accessors only touch the character card (`character.data.extensions.memory_graph.{schemaOverride,advancedOverride}`); they never mutate the global memory-graph settings.
 
+## Lookup API
+
+Alongside `openSession` and the override accessors, the `'memory-graph'` extension api publishes a set of lookup methods for read-only, frozen access to nodes / edges of the active chat's store. The intended consumers are external frontends (e.g. inline message UIs, sidebar viewers) and any extension that wants targeted node/edge access without opening a full session.
+
+All returns follow the same `NodeView` / `EdgeView` freeze contract as `openSession`'s read surface — caller never sees a mutable store reference.
+
+```js
+const mg = ctx.getExtensionApi('memory-graph');
+if (!mg) { /* memory-graph not installed */ return; }
+
+const node = await mg.getNodeById(ctx, 'n_42');
+const nodes = await mg.getNodesByIds(ctx, ['n_42', 'n_43']);
+
+const event = await mg.findEventBySeq(ctx, 17);
+const bundle = await mg.findEventBundleBySeq(ctx, 17);
+// bundle = { event, location: NodeView|null, characters: NodeView[] }
+
+const seq = mg.getAssistantSeqForMessageIndex(ctx, messageIndex);
+const injection = mg.getCurrentInjection(ctx);
+```
+
+| Method | Returns | Purpose |
+| --- | --- | --- |
+| `getNodeById(ctx, id)` | `Promise<NodeView \| null>` | Resolve a single node by id. |
+| `getNodesByIds(ctx, ids)` | `Promise<Array<NodeView \| null>>` | Batch resolve; result is aligned to input order, `null` entries mark missing / invalid ids. |
+| `findEventBySeq(ctx, seq)` | `Promise<NodeView \| null>` | Find the non-archived `event` node whose `floorRange` covers `seq`. Highest `seqTo` wins on overlap. |
+| `findEventBundleBySeq(ctx, seq)` | `Promise<{ event: NodeView, location: NodeView \| null, characters: NodeView[] } \| null>` | Same lookup as `findEventBySeq`, plus the `location_state` linked via `occurred_at` and the `character_sheet` nodes linked via `involved_in`. |
+| `getAssistantSeqForMessageIndex(ctx, messageIndex)` | `number \| null` | Translate a chat message index into the 1-based count of extractable assistant messages up to and including that index. `null` when no extractable assistant message exists at/before `messageIndex`. |
+| `getCurrentInjection(ctx)` | `InjectionState \| null` | Defensive copy of the current main-flow injection state. See [InjectionState](#injectionstate). |
+
+Each lookup opens a short-lived read-api factory against the active store. Callers that issue many lookups in a row should batch through `openSession()` instead — it lets one factory serve every read.
+
+## Change subscriptions
+
+The `'memory-graph'` extension api also publishes two observer hooks for callers that want to react to store / injection changes without polling.
+
+```js
+const mg = ctx.getExtensionApi('memory-graph');
+if (!mg) return;
+
+const offCommit = mg.onStoreCommit(({ chatKey }) => {
+    // Store committed — re-query through the Lookup API for fresh data.
+    // Note: the raw store reference is not exposed.
+});
+
+const offInjection = mg.onInjectionChanged(state => {
+    console.log('injection settled', state.alwaysInjectIds.size, state.recallSelectedIds.size);
+});
+
+// Later:
+offCommit();
+offInjection();
+// Or use the symmetric remover:
+mg.offStoreCommit(callback);
+```
+
+| Method | Callback payload | Purpose |
+| --- | --- | --- |
+| `onStoreCommit(cb)` | `{ chatKey: string }` | Fires after a session-write or recall replay commit lands. Returns an idempotent unsubscribe. |
+| `offStoreCommit(cb)` | — | Symmetric remove for `onStoreCommit`. Returns `boolean`. |
+| `onInjectionChanged(cb)` | [`InjectionState`](#injectionstate) | Fires when the main-flow recall pipeline settles on a new injection decision. Returns an idempotent unsubscribe. |
+
+Listener errors are caught and logged; one bad subscriber cannot block the others.
+
 
 ## Overview
 

--- a/docs/zh-CN/development/extension-api/memory-graph.md
+++ b/docs/zh-CN/development/extension-api/memory-graph.md
@@ -113,6 +113,70 @@ await mg.removeCharacterAdvancedOverride(ctx, avatar);
 
 这些访问器只动角色卡（`character.data.extensions.memory_graph.{schemaOverride,advancedOverride}`），从来不修改全局记忆图设置。
 
+## 查询 API
+
+除了 `openSession` 和 override 访问器，`'memory-graph'` extension api 还发布了一组查询方法，供外部前端（例如内联消息 UI、侧栏查看器）和任何想做定向节点 / 边访问、又不想开整套 session 的扩展使用，提供对当前聊天 store 的只读、冻结访问。
+
+所有返回值都遵守 `openSession` 读面同一套 `NodeView` / `EdgeView` 冻结契约 —— 调用方永远拿不到可变的 store 引用。
+
+```js
+const mg = ctx.getExtensionApi('memory-graph');
+if (!mg) { /* 记忆图未安装 */ return; }
+
+const node = await mg.getNodeById(ctx, 'n_42');
+const nodes = await mg.getNodesByIds(ctx, ['n_42', 'n_43']);
+
+const event = await mg.findEventBySeq(ctx, 17);
+const bundle = await mg.findEventBundleBySeq(ctx, 17);
+// bundle = { event, location: NodeView|null, characters: NodeView[] }
+
+const seq = mg.getAssistantSeqForMessageIndex(ctx, messageIndex);
+const injection = mg.getCurrentInjection(ctx);
+```
+
+| 方法 | 返回 | 用途 |
+| --- | --- | --- |
+| `getNodeById(ctx, id)` | `Promise<NodeView \| null>` | 按 id 解析单个节点。 |
+| `getNodesByIds(ctx, ids)` | `Promise<Array<NodeView \| null>>` | 批量解析；返回数组与输入顺序对齐，`null` 表示该 id 缺失或非法。 |
+| `findEventBySeq(ctx, seq)` | `Promise<NodeView \| null>` | 找到 `floorRange` 覆盖 `seq` 的非归档 `event` 节点；多个范围在 `seq` 上重叠时，取 `seqTo` 最大者。 |
+| `findEventBundleBySeq(ctx, seq)` | `Promise<{ event: NodeView, location: NodeView \| null, characters: NodeView[] } \| null>` | 与 `findEventBySeq` 同一次查找，并把通过 `occurred_at` 关联的 `location_state` 与通过 `involved_in` 关联的 `character_sheet` 一起取回。 |
+| `getAssistantSeqForMessageIndex(ctx, messageIndex)` | `number \| null` | 把聊天消息索引翻译为"到 `messageIndex` 为止可抽取 assistant 消息的 1-based 计数"；`messageIndex` 之前没有可抽取的 assistant 消息时返回 `null`。 |
+| `getCurrentInjection(ctx)` | `InjectionState \| null` | 当前主流注入状态的防御性拷贝；见 [InjectionState](#injectionstate)。 |
+
+每次查询都会针对活动 store 打开一个短生命周期的 read-api 工厂。一次性发起多次查询的调用方应改走 `openSession()` —— 一个工厂可以服务所有读取。
+
+## 变更订阅
+
+`'memory-graph'` extension api 还发布了两个观察者钩子，供想响应 store / 注入变化、又不想轮询的调用方使用。
+
+```js
+const mg = ctx.getExtensionApi('memory-graph');
+if (!mg) return;
+
+const offCommit = mg.onStoreCommit(({ chatKey }) => {
+    // store 已提交 —— 通过查询 API 重新查询最新数据。
+    // 注意：原始 store 引用不会被暴露。
+});
+
+const offInjection = mg.onInjectionChanged(state => {
+    console.log('injection settled', state.alwaysInjectIds.size, state.recallSelectedIds.size);
+});
+
+// 之后：
+offCommit();
+offInjection();
+// 或者用对称的 remover：
+mg.offStoreCommit(callback);
+```
+
+| 方法 | 回调入参 | 用途 |
+| --- | --- | --- |
+| `onStoreCommit(cb)` | `{ chatKey: string }` | 在 session 写入或召回回放提交落地之后触发；返回幂等的退订函数。 |
+| `offStoreCommit(cb)` | — | `onStoreCommit` 的对称移除；返回 `boolean`。 |
+| `onInjectionChanged(cb)` | [`InjectionState`](#injectionstate) | 主流召回流水线确定新的注入决策时触发；返回幂等的退订函数。 |
+
+监听器抛错会被捕获并日志化；一个坏订阅者无法阻塞其他订阅者。
+
 
 ## 概览
 

--- a/docs/zh-TW/development/extension-api/memory-graph.md
+++ b/docs/zh-TW/development/extension-api/memory-graph.md
@@ -113,6 +113,70 @@ await mg.removeCharacterAdvancedOverride(ctx, avatar);
 
 這些存取器只動角色卡（`character.data.extensions.memory_graph.{schemaOverride,advancedOverride}`），從來不修改全域記憶圖設定。
 
+## 查詢 API
+
+除了 `openSession` 和 override 存取器，`'memory-graph'` extension api 還發佈了一組查詢方法，供外部前端（例如內聯訊息 UI、側欄檢視器）和任何想做定向節點 / 邊存取、又不想開整套 session 的擴充使用，提供對當前聊天 store 的唯讀、凍結存取。
+
+所有回傳值都遵守 `openSession` 讀面同一套 `NodeView` / `EdgeView` 凍結契約 —— 呼叫端永遠拿不到可變的 store 參照。
+
+```js
+const mg = ctx.getExtensionApi('memory-graph');
+if (!mg) { /* 記憶圖未安裝 */ return; }
+
+const node = await mg.getNodeById(ctx, 'n_42');
+const nodes = await mg.getNodesByIds(ctx, ['n_42', 'n_43']);
+
+const event = await mg.findEventBySeq(ctx, 17);
+const bundle = await mg.findEventBundleBySeq(ctx, 17);
+// bundle = { event, location: NodeView|null, characters: NodeView[] }
+
+const seq = mg.getAssistantSeqForMessageIndex(ctx, messageIndex);
+const injection = mg.getCurrentInjection(ctx);
+```
+
+| 方法 | 回傳 | 用途 |
+| --- | --- | --- |
+| `getNodeById(ctx, id)` | `Promise<NodeView \| null>` | 按 id 解析單個節點。 |
+| `getNodesByIds(ctx, ids)` | `Promise<Array<NodeView \| null>>` | 批次解析；回傳陣列與輸入順序對齊，`null` 表示該 id 缺失或非法。 |
+| `findEventBySeq(ctx, seq)` | `Promise<NodeView \| null>` | 找到 `floorRange` 覆蓋 `seq` 的非歸檔 `event` 節點；多個範圍在 `seq` 上重疊時，取 `seqTo` 最大者。 |
+| `findEventBundleBySeq(ctx, seq)` | `Promise<{ event: NodeView, location: NodeView \| null, characters: NodeView[] } \| null>` | 與 `findEventBySeq` 同一次查找，並把透過 `occurred_at` 關聯的 `location_state` 與透過 `involved_in` 關聯的 `character_sheet` 一起取回。 |
+| `getAssistantSeqForMessageIndex(ctx, messageIndex)` | `number \| null` | 把聊天訊息索引翻譯為「到 `messageIndex` 為止可抽取 assistant 訊息的 1-based 計數」；`messageIndex` 之前沒有可抽取的 assistant 訊息時回傳 `null`。 |
+| `getCurrentInjection(ctx)` | `InjectionState \| null` | 當前主流注入狀態的防禦性拷貝；見 [InjectionState](#injectionstate)。 |
+
+每次查詢都會針對活動 store 開啟一個短生命週期的 read-api 工廠。一次性發起多次查詢的呼叫端應改走 `openSession()` —— 一個工廠可以服務所有讀取。
+
+## 變更訂閱
+
+`'memory-graph'` extension api 還發佈了兩個觀察者掛鉤，供想響應 store / 注入變化、又不想輪詢的呼叫端使用。
+
+```js
+const mg = ctx.getExtensionApi('memory-graph');
+if (!mg) return;
+
+const offCommit = mg.onStoreCommit(({ chatKey }) => {
+    // store 已提交 —— 透過查詢 API 重新查詢最新資料。
+    // 注意：原始 store 參照不會被暴露。
+});
+
+const offInjection = mg.onInjectionChanged(state => {
+    console.log('injection settled', state.alwaysInjectIds.size, state.recallSelectedIds.size);
+});
+
+// 之後：
+offCommit();
+offInjection();
+// 或者用對稱的 remover：
+mg.offStoreCommit(callback);
+```
+
+| 方法 | 回呼入參 | 用途 |
+| --- | --- | --- |
+| `onStoreCommit(cb)` | `{ chatKey: string }` | 在 session 寫入或召回回放提交落地之後觸發；回傳冪等的退訂函式。 |
+| `offStoreCommit(cb)` | — | `onStoreCommit` 的對稱移除；回傳 `boolean`。 |
+| `onInjectionChanged(cb)` | [`InjectionState`](#injectionstate) | 主流召回流水線確定新的注入決策時觸發；回傳冪等的退訂函式。 |
+
+監聽器拋錯會被捕獲並日誌化；一個壞訂閱者無法阻塞其他訂閱者。
+
 
 ## 概覽
 

--- a/public/scripts/extensions/memory-graph/api.js
+++ b/public/scripts/extensions/memory-graph/api.js
@@ -23,9 +23,18 @@
 
 const registerExtensionApi = Luker.getContext().registerExtensionApi;
 import {
+    getCurrentlyInjectedNodeIds,
+    addInjectionChangedListener,
+} from './external-api.js';
+import {
     ensureMemoryStoreLoaded,
     resolveChatKeyForSession,
     commitSessionMutation,
+    getMemoryStore,
+    findEventNodeForSeq,
+    resolveEventCardData,
+    addStoreCommitListener,
+    findAffectedAssistantSeqFromMessageIndex,
 } from './main.js';
 import { getMemoryGraphReadApi } from './read-api.js';
 import { getMemoryGraphWriteApi } from './write-api.js';
@@ -91,16 +100,36 @@ export async function openSession(context) {
 
 registerExtensionApi('memory-graph', {
     openSession,
-    // Per-character override accessors (character-overrides.js). Sibling
-    // plugins that surface per-character memory-graph config (CardApp's
-    // ctx.getMemoryGraphSchema / setMemoryGraphSchema, CEA Studio's
-    // character_get_memory_graph tool) consume these. Direct ES-module
-    // import from another plugin is forbidden by the plugin↔plugin
-    // boundary rule.
+    // Per-character override accessors (character-overrides.js).
     getSchemaScopeInfo,
     getAdvancedScopeInfo,
     persistCharacterSchemaOverride,
     removeCharacterSchemaOverride,
     persistCharacterAdvancedOverride,
     removeCharacterAdvancedOverride,
+    // Inline card / event data API — consumed by 酒馆助手 and third-party frontends.
+    onStoreCommit: (cb) => addStoreCommitListener(cb),
+    getCardDataForSeq: (context, seq) => {
+        const store = getMemoryStore(context);
+        if (!store) return null;
+        const eventNode = findEventNodeForSeq(store, Number(seq));
+        return eventNode ? resolveEventCardData(store, eventNode) : null;
+    },
+    // Injection observation — fires when recall pipeline settles on injected nodes.
+    // Callback receives { alwaysInjectIds: Set, recallSelectedIds: Set, visibleIds: Set }.
+    // Returns an unsubscribe function.
+    onInjectionChanged: (cb) => addInjectionChangedListener(cb),
+    // Snapshot of what's currently injected for a given context.
+    getCurrentInjection: (context) => getCurrentlyInjectedNodeIds(context),
+    // Resolve node objects from the store by their ids. Returns an array in
+    // the same order as the input ids (null entries for missing nodes).
+    getNodesByIds: (context, ids) => {
+        const store = getMemoryStore(context);
+        if (!store || !Array.isArray(ids)) return [];
+        return ids.map(id => store.nodes[String(id)] ?? null);
+    },
+    // Resolve the assistant seq number for a given chat message index.
+    // seq is 1-based count of extractable assistant messages up to and including msgIndex.
+    getSeqForMessageIndex: (context, messageIndex) =>
+        findAffectedAssistantSeqFromMessageIndex(context, messageIndex),
 });

--- a/public/scripts/extensions/memory-graph/api.js
+++ b/public/scripts/extensions/memory-graph/api.js
@@ -30,10 +30,8 @@ import {
     ensureMemoryStoreLoaded,
     resolveChatKeyForSession,
     commitSessionMutation,
-    getMemoryStore,
-    findEventNodeForSeq,
-    resolveEventCardData,
     addStoreCommitListener,
+    removeStoreCommitListener,
     findAffectedAssistantSeqFromMessageIndex,
 } from './main.js';
 import { getMemoryGraphReadApi } from './read-api.js';
@@ -98,6 +96,25 @@ export async function openSession(context) {
     });
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// Lookup helpers used by the registered API methods below. Each opens a
+// short-lived read-api factory against the freshly-loaded runtime store, so
+// returned views are deep-frozen via the same path `openSession` already uses.
+// ────────────────────────────────────────────────────────────────────────────
+
+async function withReadApi(context) {
+    if (!context || typeof context !== 'object') return null;
+    let store;
+    try {
+        store = await ensureMemoryStoreLoaded(context);
+    } catch (err) {
+        console.warn('[memory-graph] lookup: failed to load runtime store', err);
+        return null;
+    }
+    if (!store) return null;
+    return getMemoryGraphReadApi(store, context);
+}
+
 registerExtensionApi('memory-graph', {
     openSession,
     // Per-character override accessors (character-overrides.js).
@@ -107,29 +124,142 @@ registerExtensionApi('memory-graph', {
     removeCharacterSchemaOverride,
     persistCharacterAdvancedOverride,
     removeCharacterAdvancedOverride,
-    // Inline card / event data API — consumed by 酒馆助手 and third-party frontends.
+
+    // ── Lookup API ──────────────────────────────────────────────────────
+    // Frozen NodeView / EdgeView returns — same shape and freeze contract as
+    // openSession()'s read surface. Each call opens a fresh short-lived read
+    // factory; callers that issue many lookups in a row should batch through
+    // openSession() instead to share one factory.
+
+    /**
+     * Resolve a single node by id. Returns `NodeView | null`.
+     */
+    getNodeById: async (context, id) => {
+        if (id === null || id === undefined) return null;
+        const api = await withReadApi(context);
+        return api ? api.getNode(String(id).trim()) : null;
+    },
+
+    /**
+     * Resolve multiple nodes by id. Returns `Array<NodeView | null>` in the
+     * same order as the input ids (null entries for missing / invalid ids).
+     */
+    getNodesByIds: async (context, ids) => {
+        if (!Array.isArray(ids)) return [];
+        const api = await withReadApi(context);
+        if (!api) return [];
+        return ids.map(id => {
+            if (id === null || id === undefined) return null;
+            const key = String(id).trim();
+            return key ? api.getNode(key) : null;
+        });
+    },
+
+    /**
+     * Find the non-archived `event` node whose floor/seq range covers `seq`.
+     * When multiple ranges overlap on `seq`, prefers the node with the highest
+     * seqTo (most recent). Returns `NodeView | null`.
+     */
+    findEventBySeq: async (context, seq) => {
+        const target = Number(seq);
+        if (!Number.isFinite(target)) return null;
+        const api = await withReadApi(context);
+        if (!api) return null;
+        return pickEventCoveringSeq(api.listNodes({ types: ['event'] }), target);
+    },
+
+    /**
+     * Same lookup as `findEventBySeq`, plus the location_state linked via
+     * `occurred_at` and the character_sheet nodes linked via `involved_in`.
+     * Returns `{ event: NodeView, location: NodeView|null, characters: NodeView[] } | null`.
+     * `characters` is in edge-insertion order with duplicates dropped.
+     */
+    findEventBundleBySeq: async (context, seq) => {
+        const target = Number(seq);
+        if (!Number.isFinite(target)) return null;
+        const api = await withReadApi(context);
+        if (!api) return null;
+        const event = pickEventCoveringSeq(api.listNodes({ types: ['event'] }), target);
+        if (!event) return null;
+        const outgoing = api.listEdges({ from: event.id, types: ['occurred_at', 'involved_in'] });
+
+        let location = null;
+        const characters = [];
+        const seen = new Set();
+        for (const edge of outgoing) {
+            if (!location && edge.type === 'occurred_at') {
+                const node = api.getNode(edge.to);
+                if (node && node.type === 'location_state') location = node;
+            } else if (edge.type === 'involved_in') {
+                const node = api.getNode(edge.to);
+                if (node && node.type === 'character_sheet' && !seen.has(node.id)) {
+                    seen.add(node.id);
+                    characters.push(node);
+                }
+            }
+        }
+        return Object.freeze({ event, location, characters: Object.freeze(characters) });
+    },
+
+    /**
+     * Translate a chat message index into the 1-based count of extractable
+     * assistant messages up to and including that index. Returns
+     * `number | null` (null = no extractable assistant message at/before idx).
+     */
+    getAssistantSeqForMessageIndex: (context, messageIndex) => {
+        if (!context || typeof context !== 'object') return null;
+        const idx = Number(messageIndex);
+        if (!Number.isFinite(idx)) return null;
+        return findAffectedAssistantSeqFromMessageIndex(context, idx);
+    },
+
+    /**
+     * Defensive copy of the current main-flow injection state. See
+     * `InjectionState` in the Type Reference. Returns `null` for invalid
+     * context.
+     */
+    getCurrentInjection: (context) => {
+        if (!context || typeof context !== 'object') return null;
+        return getCurrentlyInjectedNodeIds(context);
+    },
+
+    // ── Change subscriptions ────────────────────────────────────────────
+
+    /**
+     * Subscribe to store-commit notifications. The callback receives a frozen
+     * `{ chatKey }` signal — re-query through the Lookup API for fresh data,
+     * the store reference is not exposed. Returns an idempotent unsubscribe.
+     */
     onStoreCommit: (cb) => addStoreCommitListener(cb),
-    getCardDataForSeq: (context, seq) => {
-        const store = getMemoryStore(context);
-        if (!store) return null;
-        const eventNode = findEventNodeForSeq(store, Number(seq));
-        return eventNode ? resolveEventCardData(store, eventNode) : null;
-    },
-    // Injection observation — fires when recall pipeline settles on injected nodes.
-    // Callback receives { alwaysInjectIds: Set, recallSelectedIds: Set, visibleIds: Set }.
-    // Returns an unsubscribe function.
+    /** Symmetric remove for `onStoreCommit`. Returns `boolean`. */
+    offStoreCommit: (cb) => removeStoreCommitListener(cb),
+
+    /**
+     * Subscribe to main-flow injection-decision changes. The callback receives
+     * a frozen `InjectionState` snapshot. Returns an idempotent unsubscribe.
+     */
     onInjectionChanged: (cb) => addInjectionChangedListener(cb),
-    // Snapshot of what's currently injected for a given context.
-    getCurrentInjection: (context) => getCurrentlyInjectedNodeIds(context),
-    // Resolve node objects from the store by their ids. Returns an array in
-    // the same order as the input ids (null entries for missing nodes).
-    getNodesByIds: (context, ids) => {
-        const store = getMemoryStore(context);
-        if (!store || !Array.isArray(ids)) return [];
-        return ids.map(id => store.nodes[String(id)] ?? null);
-    },
-    // Resolve the assistant seq number for a given chat message index.
-    // seq is 1-based count of extractable assistant messages up to and including msgIndex.
-    getSeqForMessageIndex: (context, messageIndex) =>
-        findAffectedAssistantSeqFromMessageIndex(context, messageIndex),
 });
+
+function pickEventCoveringSeq(events, target) {
+    let best = null;
+    let bestSeqTo = -Infinity;
+    for (const n of events) {
+        if (!n || n.type !== 'event' || n.archived) continue;
+        let covers = false;
+        if (n.floorRange
+            && typeof n.floorRange.start === 'number' && typeof n.floorRange.end === 'number') {
+            covers = target >= n.floorRange.start && target <= n.floorRange.end;
+        } else if (Number.isFinite(Number(n.seqTo))) {
+            covers = target === Number(n.seqTo);
+        }
+        if (!covers) continue;
+        const nodeSeqTo = Number.isFinite(Number(n.seqTo)) ? Number(n.seqTo)
+            : (n.floorRange ? Number(n.floorRange.end) : -Infinity);
+        if (nodeSeqTo > bestSeqTo) {
+            best = n;
+            bestSeqTo = nodeSeqTo;
+        }
+    }
+    return best;
+}

--- a/public/scripts/extensions/memory-graph/main.js
+++ b/public/scripts/extensions/memory-graph/main.js
@@ -2277,6 +2277,14 @@ export function resolveChatKeyForSession(context) {
  *   5. Best-effort UI refresh — `refreshUiStats` early-returns when the
  *      popup isn't mounted, so this is safe in headless contexts.
  */
+const storeCommitListeners = new Set();
+
+/** Returns an unsubscribe function. */
+export function addStoreCommitListener(cb) {
+    storeCommitListeners.add(cb);
+    return () => storeCommitListeners.delete(cb);
+}
+
 export async function commitSessionMutation(context, chatKey, beforeStore, afterStore) {
     const key = String(chatKey || '').trim();
     const store = afterStore;
@@ -2310,6 +2318,7 @@ export async function commitSessionMutation(context, chatKey, beforeStore, after
         await persistMemoryStoreByChatKey(context, key, store, { syncPersistentProjection: false });
     }
     try { refreshUiStats(); } catch (_) { /* UI optional in headless / test env */ }
+    try { storeCommitListeners.forEach(cb => cb({ chatKey: key, store })); } catch (_) { /* listener errors are non-fatal */ }
 }
 
 /**
@@ -2871,7 +2880,7 @@ function findAssistantSeqFromPlayableSeq(context, playableSeqFrom) {
     return null;
 }
 
-function findAffectedAssistantSeqFromMessageIndex(context, messageIndex) {
+export function findAffectedAssistantSeqFromMessageIndex(context, messageIndex) {
     const targetIndex = Math.max(0, Math.floor(Number(messageIndex || 0)));
     if (!Number.isFinite(targetIndex) || targetIndex < 0) {
         return null;
@@ -13281,6 +13290,116 @@ function ensureStyles() {
         padding: 2px 7px;
     }
 }
+
+/* ── MEMORY GRAPH INLINE CARD ── */
+.mg-card {
+  --mg-amber:     #d4a853;
+  --mg-amber-dim: rgba(212,168,83,0.22);
+  --mg-amber-mid: rgba(212,168,83,0.55);
+  --mg-amber-full:rgba(212,168,83,0.88);
+  --mg-danger:    #e07a5f;
+  margin-top: 13px;
+  border-top: 1px solid var(--mg-amber-dim);
+  padding-top: 9px;
+  font-size: 13.5px;
+}
+.mg-header {
+  display: flex; align-items: stretch;
+  cursor: pointer; user-select: none;
+}
+.mg-badge {
+  display: flex; align-items: center; justify-content: center;
+  padding: 5px 8px;
+  border: 1px solid var(--mg-amber-dim); border-right: none;
+  border-radius: 2px 0 0 2px;
+  background: var(--mg-amber-dim);
+}
+.mg-badge-text {
+  font-size: 7.5px; font-weight: 700; letter-spacing: 0.15em;
+  color: var(--mg-amber-mid);
+  writing-mode: vertical-rl; text-orientation: mixed; transform: rotate(180deg);
+}
+.mg-header-main {
+  flex: 1; min-width: 0;
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 10px;
+  border: 1px solid var(--mg-amber-dim);
+  border-radius: 0 2px 2px 0;
+  background: rgba(212,168,83,0.04);
+  transition: background 0.2s;
+}
+.mg-header:hover .mg-header-main { background: rgba(212,168,83,0.08); }
+.mg-header-time {
+  flex: 1; min-width: 0;
+  font-size: 13px; color: var(--mg-amber-full);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  letter-spacing: 0.02em;
+}
+.mg-toggle {
+  font-size: 11px; font-weight: 700;
+  color: var(--mg-amber-mid); flex-shrink: 0;
+  transition: color 0.2s;
+}
+.mg-header:hover .mg-toggle { color: var(--mg-amber-full); }
+.mg-body {
+  overflow: hidden; max-height: 0; opacity: 0;
+  transition: max-height 0.38s cubic-bezier(0.4,0,0.2,1), opacity 0.28s ease;
+}
+.mg-card[data-open] .mg-body { max-height: 900px; opacity: 1; }
+.mg-grid {
+  border: 1px solid var(--mg-amber-dim);
+  border-top: none;
+  border-radius: 0 0 2px 2px;
+}
+.mg-row {
+  border-top: 1px solid var(--mg-amber-dim);
+  padding: 8px 11px;
+}
+.mg-row.two-col {
+  display: grid; grid-template-columns: 1fr 1fr;
+}
+.mg-row.two-col .mg-cell + .mg-cell {
+  border-left: 1px solid var(--mg-amber-dim); padding-left: 11px;
+}
+.mg-cell { display: flex; flex-direction: column; gap: 4px; }
+.mg-label {
+  font-size: 8px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--mg-amber-mid);
+}
+.mg-label::after { content: '::'; opacity: 0.5; }
+.mg-val { line-height: 1.6; color: var(--SmartThemeBodyColor, #c8c5c5); opacity: 0.9; }
+.mg-loc-sep { color: var(--mg-amber-mid); margin: 0 1px; font-size: 11px; }
+.mg-danger-inner { display: flex; align-items: center; gap: 7px; }
+.mg-danger-pip {
+  width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0;
+  background: var(--mg-danger);
+}
+.mg-danger-text { color: var(--SmartThemeBodyColor, #c8c5c5); opacity: 0.85; }
+.mg-agents { display: flex; flex-direction: column; gap: 8px; }
+.mg-agent { display: flex; flex-direction: column; gap: 3px; }
+.mg-agent-name {
+  font-size: 13.5px; font-weight: 600;
+  color: var(--mg-amber-full); letter-spacing: 0.04em;
+}
+.mg-agent-name::before { content: '▸ '; font-size: 10px; opacity: 0.6; }
+.mg-agent-goal {
+  font-size: 13px;
+  color: var(--SmartThemeBodyColor, #c8c5c5); opacity: 0.58;
+  padding-left: 14px;
+  border-left: 1px solid var(--mg-amber-dim);
+}
+.mg-summary {
+  line-height: 1.82;
+  color: var(--SmartThemeBodyColor, #c8c5c5); opacity: 0.85;
+  border-left: 2px solid var(--mg-amber-dim);
+  padding-left: 10px;
+}
+.mg-footer {
+  padding: 5px 11px;
+  border-top: 1px solid var(--mg-amber-dim);
+  font-size: 8.5px; color: var(--mg-amber-mid); opacity: 0.45;
+  letter-spacing: 0.08em; text-align: right;
+}
 </style>`);
 }
 
@@ -15526,13 +15645,103 @@ jQuery(() => {
         const runtimeContext = getContext();
         const newChatKey = getChatKey(runtimeContext);
         if (newChatKey && newChatKey !== 'invalid_target') {
+            let refreshedStore = null;
             try {
-                await refreshMemoryStoreCacheFromFloorState(runtimeContext, newChatKey);
+                refreshedStore = await refreshMemoryStoreCacheFromFloorState(runtimeContext, newChatKey);
             } catch (error) {
                 console.warn(`[${MODULE_NAME}] Failed to refresh memory store cache on CHAT_CHANGED`, error);
             }
             refreshUiStats();
+            if (refreshedStore) {
+                // Inline UI rendering is handled by memory-graph-ui extension via API.
+            }
         }
         void syncPersistentProjectionForCurrentChat();
     });
+
+    setupInlineUiHooks(getContext());
 });
+
+// ============================================================================
+// INLINE UI: hooks delegated to memory-graph-ui extension via API
+// ============================================================================
+
+function setupInlineUiHooks(_context) {
+    // Rendering is handled by the memory-graph-ui extension.
+    // This stub keeps the call site below intact.
+}
+
+/** Returns the first non-archived event node whose floor/seq range covers `seq`, or null. */
+export function findEventNodeForSeq(store, seq) {
+    if (!store || typeof store.nodes !== 'object') return null;
+    return Object.values(store.nodes).find(n => {
+        if (n.type !== 'event' || n.archived) return false;
+        if (n.floorRange && typeof n.floorRange === 'object') {
+            return seq >= n.floorRange.start && seq <= n.floorRange.end;
+        }
+        return n.seqTo ? seq === Number(n.seqTo) : false;
+    }) ?? null;
+}
+
+/**
+ * Extracts all display data for a given event node.
+ * Walks occurred_at / involved_in edges; falls back to regex on summary text.
+ * Returns { time, summaryText, location, danger, characters }.
+ * Any field may be null/empty — callers should omit those rows.
+ */
+export function resolveEventCardData(store, eventNode) {
+    const rawSummary = getNodeSummary(eventNode) || '';
+
+    let time = null;
+    let summaryText = rawSummary;
+    const timeMatch = rawSummary.match(/^时间[：:]\s*(.+?)[；;]\s*/);
+    if (timeMatch) {
+        time = timeMatch[1].trim();
+        summaryText = rawSummary.slice(timeMatch[0].length).trim();
+    }
+
+    let location = null;
+    let danger = null;
+    const characters = [];
+    const seenCharIds = new Set();
+
+    if (store && Array.isArray(store.edges)) {
+        for (const edge of store.edges) {
+            if (edge.type === 'occurred_at' && edge.from === eventNode.id) {
+                const locNode = store.nodes[edge.to];
+                if (locNode && locNode.type === 'location_state') {
+                    const f = locNode.fields || {};
+                    location = f.title || locNode.title || null;
+                    danger = f.danger || f.danger_level || null;
+                }
+            }
+            if (edge.type === 'involved_in') {
+                const charId = edge.from === eventNode.id ? edge.to
+                    : edge.to === eventNode.id ? edge.from
+                    : null;
+                if (charId && !seenCharIds.has(charId)) {
+                    seenCharIds.add(charId);
+                    const charNode = store.nodes[charId];
+                    if (charNode && charNode.type === 'character_sheet') {
+                        const f = charNode.fields || {};
+                        const name = f.title || charNode.title || null;
+                        const goal = f.goal || null;
+                        if (name) characters.push({ name, goal });
+                    }
+                }
+            }
+        }
+    }
+
+    if (!location) {
+        const m = rawSummary.match(/地点[：:]\s*(.+?)[；;\n]/);
+        if (m) location = m[1].trim();
+    }
+
+    return { time, summaryText, location, danger, characters };
+}
+
+// mgIsColorLight / mgApplyTheme / setupMgThemeObserver / mgEscHtml / mgRenderLocation
+// / injectInlineUiForSeq / refreshInlineUis — all moved to memory-graph-ui extension.
+// The functions below (findEventNodeForSeq, resolveEventCardData) remain here because
+// they are part of the memory-graph public API surface (consumed via api.js).

--- a/public/scripts/extensions/memory-graph/main.js
+++ b/public/scripts/extensions/memory-graph/main.js
@@ -2279,10 +2279,21 @@ export function resolveChatKeyForSession(context) {
  */
 const storeCommitListeners = new Set();
 
-/** Returns an unsubscribe function. */
+/**
+ * Registers a store-commit listener. The callback receives a frozen
+ * `{ chatKey }` signal — re-query through the api.js Lookup API for fresh
+ * data; the cached runtime store is not exposed. Returns an idempotent
+ * unsubscribe function; non-function inputs return a no-op unsubscribe.
+ */
 export function addStoreCommitListener(cb) {
+    if (typeof cb !== 'function') return () => { /* no-op for invalid input */ };
     storeCommitListeners.add(cb);
-    return () => storeCommitListeners.delete(cb);
+    return () => { storeCommitListeners.delete(cb); };
+}
+
+/** Matches the add/remove pair shape used by external-api.js. */
+export function removeStoreCommitListener(cb) {
+    return storeCommitListeners.delete(cb);
 }
 
 export async function commitSessionMutation(context, chatKey, beforeStore, afterStore) {
@@ -2318,7 +2329,21 @@ export async function commitSessionMutation(context, chatKey, beforeStore, after
         await persistMemoryStoreByChatKey(context, key, store, { syncPersistentProjection: false });
     }
     try { refreshUiStats(); } catch (_) { /* UI optional in headless / test env */ }
-    try { storeCommitListeners.forEach(cb => cb({ chatKey: key, store })); } catch (_) { /* listener errors are non-fatal */ }
+    if (storeCommitListeners.size > 0) {
+        // Frozen signal — re-query through the Lookup API for fresh data; the
+        // cached runtime store is not exposed. Each listener is wrapped
+        // individually so one throw doesn't abort iteration over the rest.
+        const snapshot = Object.freeze({ chatKey: key });
+        for (const cb of storeCommitListeners) {
+            try {
+                cb(snapshot);
+            } catch (err) {
+                try {
+                    console.warn(`[${MODULE_NAME}] store-commit listener threw:`, err);
+                } catch (_) { /* logger itself failed; ignore */ }
+            }
+        }
+    }
 }
 
 /**
@@ -13290,116 +13315,6 @@ function ensureStyles() {
         padding: 2px 7px;
     }
 }
-
-/* ── MEMORY GRAPH INLINE CARD ── */
-.mg-card {
-  --mg-amber:     #d4a853;
-  --mg-amber-dim: rgba(212,168,83,0.22);
-  --mg-amber-mid: rgba(212,168,83,0.55);
-  --mg-amber-full:rgba(212,168,83,0.88);
-  --mg-danger:    #e07a5f;
-  margin-top: 13px;
-  border-top: 1px solid var(--mg-amber-dim);
-  padding-top: 9px;
-  font-size: 13.5px;
-}
-.mg-header {
-  display: flex; align-items: stretch;
-  cursor: pointer; user-select: none;
-}
-.mg-badge {
-  display: flex; align-items: center; justify-content: center;
-  padding: 5px 8px;
-  border: 1px solid var(--mg-amber-dim); border-right: none;
-  border-radius: 2px 0 0 2px;
-  background: var(--mg-amber-dim);
-}
-.mg-badge-text {
-  font-size: 7.5px; font-weight: 700; letter-spacing: 0.15em;
-  color: var(--mg-amber-mid);
-  writing-mode: vertical-rl; text-orientation: mixed; transform: rotate(180deg);
-}
-.mg-header-main {
-  flex: 1; min-width: 0;
-  display: flex; align-items: center; gap: 10px;
-  padding: 6px 10px;
-  border: 1px solid var(--mg-amber-dim);
-  border-radius: 0 2px 2px 0;
-  background: rgba(212,168,83,0.04);
-  transition: background 0.2s;
-}
-.mg-header:hover .mg-header-main { background: rgba(212,168,83,0.08); }
-.mg-header-time {
-  flex: 1; min-width: 0;
-  font-size: 13px; color: var(--mg-amber-full);
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-  letter-spacing: 0.02em;
-}
-.mg-toggle {
-  font-size: 11px; font-weight: 700;
-  color: var(--mg-amber-mid); flex-shrink: 0;
-  transition: color 0.2s;
-}
-.mg-header:hover .mg-toggle { color: var(--mg-amber-full); }
-.mg-body {
-  overflow: hidden; max-height: 0; opacity: 0;
-  transition: max-height 0.38s cubic-bezier(0.4,0,0.2,1), opacity 0.28s ease;
-}
-.mg-card[data-open] .mg-body { max-height: 900px; opacity: 1; }
-.mg-grid {
-  border: 1px solid var(--mg-amber-dim);
-  border-top: none;
-  border-radius: 0 0 2px 2px;
-}
-.mg-row {
-  border-top: 1px solid var(--mg-amber-dim);
-  padding: 8px 11px;
-}
-.mg-row.two-col {
-  display: grid; grid-template-columns: 1fr 1fr;
-}
-.mg-row.two-col .mg-cell + .mg-cell {
-  border-left: 1px solid var(--mg-amber-dim); padding-left: 11px;
-}
-.mg-cell { display: flex; flex-direction: column; gap: 4px; }
-.mg-label {
-  font-size: 8px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
-  color: var(--mg-amber-mid);
-}
-.mg-label::after { content: '::'; opacity: 0.5; }
-.mg-val { line-height: 1.6; color: var(--SmartThemeBodyColor, #c8c5c5); opacity: 0.9; }
-.mg-loc-sep { color: var(--mg-amber-mid); margin: 0 1px; font-size: 11px; }
-.mg-danger-inner { display: flex; align-items: center; gap: 7px; }
-.mg-danger-pip {
-  width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0;
-  background: var(--mg-danger);
-}
-.mg-danger-text { color: var(--SmartThemeBodyColor, #c8c5c5); opacity: 0.85; }
-.mg-agents { display: flex; flex-direction: column; gap: 8px; }
-.mg-agent { display: flex; flex-direction: column; gap: 3px; }
-.mg-agent-name {
-  font-size: 13.5px; font-weight: 600;
-  color: var(--mg-amber-full); letter-spacing: 0.04em;
-}
-.mg-agent-name::before { content: '▸ '; font-size: 10px; opacity: 0.6; }
-.mg-agent-goal {
-  font-size: 13px;
-  color: var(--SmartThemeBodyColor, #c8c5c5); opacity: 0.58;
-  padding-left: 14px;
-  border-left: 1px solid var(--mg-amber-dim);
-}
-.mg-summary {
-  line-height: 1.82;
-  color: var(--SmartThemeBodyColor, #c8c5c5); opacity: 0.85;
-  border-left: 2px solid var(--mg-amber-dim);
-  padding-left: 10px;
-}
-.mg-footer {
-  padding: 5px 11px;
-  border-top: 1px solid var(--mg-amber-dim);
-  font-size: 8.5px; color: var(--mg-amber-mid); opacity: 0.45;
-  letter-spacing: 0.08em; text-align: right;
-}
 </style>`);
 }
 
@@ -15645,103 +15560,13 @@ jQuery(() => {
         const runtimeContext = getContext();
         const newChatKey = getChatKey(runtimeContext);
         if (newChatKey && newChatKey !== 'invalid_target') {
-            let refreshedStore = null;
             try {
-                refreshedStore = await refreshMemoryStoreCacheFromFloorState(runtimeContext, newChatKey);
+                await refreshMemoryStoreCacheFromFloorState(runtimeContext, newChatKey);
             } catch (error) {
                 console.warn(`[${MODULE_NAME}] Failed to refresh memory store cache on CHAT_CHANGED`, error);
             }
             refreshUiStats();
-            if (refreshedStore) {
-                // Inline UI rendering is handled by memory-graph-ui extension via API.
-            }
         }
         void syncPersistentProjectionForCurrentChat();
     });
-
-    setupInlineUiHooks(getContext());
 });
-
-// ============================================================================
-// INLINE UI: hooks delegated to memory-graph-ui extension via API
-// ============================================================================
-
-function setupInlineUiHooks(_context) {
-    // Rendering is handled by the memory-graph-ui extension.
-    // This stub keeps the call site below intact.
-}
-
-/** Returns the first non-archived event node whose floor/seq range covers `seq`, or null. */
-export function findEventNodeForSeq(store, seq) {
-    if (!store || typeof store.nodes !== 'object') return null;
-    return Object.values(store.nodes).find(n => {
-        if (n.type !== 'event' || n.archived) return false;
-        if (n.floorRange && typeof n.floorRange === 'object') {
-            return seq >= n.floorRange.start && seq <= n.floorRange.end;
-        }
-        return n.seqTo ? seq === Number(n.seqTo) : false;
-    }) ?? null;
-}
-
-/**
- * Extracts all display data for a given event node.
- * Walks occurred_at / involved_in edges; falls back to regex on summary text.
- * Returns { time, summaryText, location, danger, characters }.
- * Any field may be null/empty — callers should omit those rows.
- */
-export function resolveEventCardData(store, eventNode) {
-    const rawSummary = getNodeSummary(eventNode) || '';
-
-    let time = null;
-    let summaryText = rawSummary;
-    const timeMatch = rawSummary.match(/^时间[：:]\s*(.+?)[；;]\s*/);
-    if (timeMatch) {
-        time = timeMatch[1].trim();
-        summaryText = rawSummary.slice(timeMatch[0].length).trim();
-    }
-
-    let location = null;
-    let danger = null;
-    const characters = [];
-    const seenCharIds = new Set();
-
-    if (store && Array.isArray(store.edges)) {
-        for (const edge of store.edges) {
-            if (edge.type === 'occurred_at' && edge.from === eventNode.id) {
-                const locNode = store.nodes[edge.to];
-                if (locNode && locNode.type === 'location_state') {
-                    const f = locNode.fields || {};
-                    location = f.title || locNode.title || null;
-                    danger = f.danger || f.danger_level || null;
-                }
-            }
-            if (edge.type === 'involved_in') {
-                const charId = edge.from === eventNode.id ? edge.to
-                    : edge.to === eventNode.id ? edge.from
-                    : null;
-                if (charId && !seenCharIds.has(charId)) {
-                    seenCharIds.add(charId);
-                    const charNode = store.nodes[charId];
-                    if (charNode && charNode.type === 'character_sheet') {
-                        const f = charNode.fields || {};
-                        const name = f.title || charNode.title || null;
-                        const goal = f.goal || null;
-                        if (name) characters.push({ name, goal });
-                    }
-                }
-            }
-        }
-    }
-
-    if (!location) {
-        const m = rawSummary.match(/地点[：:]\s*(.+?)[；;\n]/);
-        if (m) location = m[1].trim();
-    }
-
-    return { time, summaryText, location, danger, characters };
-}
-
-// mgIsColorLight / mgApplyTheme / setupMgThemeObserver / mgEscHtml / mgRenderLocation
-// / injectInlineUiForSeq / refreshInlineUis — all moved to memory-graph-ui extension.
-// The functions below (findEventNodeForSeq, resolveEventCardData) remain here because
-// they are part of the memory-graph public API surface (consumed via api.js).


### PR DESCRIPTION
- api.js: register getCardDataForSeq, getSeqForMessageIndex, getNodesByIds, getCurrentInjection, onStoreCommit, onInjectionChanged on the extension API
- main.js: export findEventNodeForSeq, resolveEventCardData, findAffectedAssistantSeqFromMessageIndex; add addStoreCommitListener hook; delegate inline rendering to external scripts via stub setupInlineUiHooks; inject base mg-card CSS so JS-Slash-Runner scripts can share the stylesheet

<!-- Put X in the box below to confirm -->

## Checklist:

- [ ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
