### PR TITLE
fix(cpa-iteration): readStore 未解包 presets.state.get 信封导致会话无法持久化

### DIFF
--- a/public/scripts/extensions/character-editor-assistant/editor-iteration/studio.js
+++ b/public/scripts/extensions/character-editor-assistant/editor-iteration/studio.js
@@ -657,19 +657,9 @@ function buildSeedTaskMessages(state, systemPrompt) {
         const readToolCalls = toolCalls.filter(c => resultCallIds.has(String(c?.id || '')));
 
         if (role === 'assistant' && readToolCalls.length > 0) {
-            const persistedReasoning = typeof m?.reasoning === 'string' ? m.reasoning : '';
-            const persistedReasoningBlocks = Array.isArray(m?.reasoningBlocks) && m.reasoningBlocks.length > 0
-                ? m.reasoningBlocks
-                : null;
-            const persistedReasoningDetails = Array.isArray(m?.reasoningDetails) && m.reasoningDetails.length > 0
-                ? m.reasoningDetails
-                : null;
             messages.push({
                 role: 'assistant',
                 content,
-                ...(persistedReasoning ? { reasoning: persistedReasoning } : {}),
-                ...(persistedReasoningBlocks ? { reasoning_blocks: persistedReasoningBlocks } : {}),
-                ...(persistedReasoningDetails ? { reasoning_details: persistedReasoningDetails } : {}),
                 tool_calls: readToolCalls.map(c => ({
                     id: String(c.id || ''),
                     type: 'function',

--- a/public/scripts/extensions/completion-preset-assistant/cpa-iteration/session-store.js
+++ b/public/scripts/extensions/completion-preset-assistant/cpa-iteration/session-store.js
@@ -121,7 +121,8 @@ export function createCpaIterationSessionStore({ getContext, getTargetRef }) {
     async function readStore() {
         const ref = getTargetRef();
         const ctx = getContext();
-        const store = await ctx.presets.state.get(SESSION_NAMESPACE, { target: ref });
+        const result = await ctx.presets.state.get(SESSION_NAMESPACE, { target: ref });
+        const store = result?.ok ? result.state : null;
         return store && Array.isArray(store.sessions)
             ? store
             : { version: 1, currentSessionId: null, sessions: [] };

--- a/public/scripts/extensions/completion-preset-assistant/cpa-iteration/studio.js
+++ b/public/scripts/extensions/completion-preset-assistant/cpa-iteration/studio.js
@@ -58,6 +58,7 @@
 const __ctx = Luker.getContext();
 const Popup = __ctx.Popup;
 const POPUP_TYPE = __ctx.POPUP_TYPE;
+const POPUP_RESULT = __ctx.POPUP_RESULT;
 const stripOpenAIConnectionFieldsFromPreset = __ctx.openai.stripPresetConnectionFields;
 import {
     applyEdits,
@@ -380,6 +381,7 @@ function buildPopupHtml({
     historyLabel,
     newSessionLabel,
     clearAllLabel,
+    importChatLabel,
     sendLabel,
     composerPlaceholder,
     referenceLabel,
@@ -403,6 +405,7 @@ function buildPopupHtml({
         <div class="cpa_it_history_actions">
             <button class="menu_button menu_button_small" data-cpa-it-action="new-session">${escapeHtmlLocal(newSessionLabel)}</button>
             <button class="menu_button menu_button_small" data-cpa-it-action="clear-history">${escapeHtmlLocal(clearAllLabel)}</button>
+            <button class="menu_button menu_button_small" data-cpa-it-action="import-chat">${escapeHtmlLocal(importChatLabel)}</button>
         </div>
     </details>
 
@@ -944,6 +947,105 @@ export async function openCpaIterationStudio(deps) {
             await sessionStore.delete(meta.id);
         }
         await startNewSession();
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Import messages from the currently open main chat.
+    // ──────────────────────────────────────────────────────────────────
+    async function importFromMainChat() {
+        const ctx = getContext();
+        const chat = ctx.chat;
+        if (!Array.isArray(chat) || chat.length === 0) {
+            try { toastr.warning(t('No chat is currently open.')); } catch { /* ignore */ }
+            return;
+        }
+
+        const dialogMessages = chat
+            .map((m, idx) => ({ ...m, _chatIdx: idx }))
+            .filter(m => !m.is_system);
+
+        if (dialogMessages.length === 0) {
+            try { toastr.warning(t('The current chat has no user or character messages to import.')); } catch { /* ignore */ }
+            return;
+        }
+
+        const listHtml = dialogMessages.map((m, i) => {
+            const role = m.is_user ? 'user' : 'assistant';
+            const name = escapeHtmlLocal(String(m.name || role));
+            const preview = escapeHtmlLocal(String(m.mes || '').slice(0, 120));
+            return `<label class="cpa_it_import_row" style="display:flex;align-items:flex-start;gap:6px;padding:4px 0;cursor:pointer;">
+                <input type="checkbox" data-cpa-import-idx="${i}" checked style="margin-top:3px;flex-shrink:0;" />
+                <span><b>${name}</b>: ${preview}${(m.mes || '').length > 120 ? '…' : ''}</span>
+            </label>`;
+        }).join('');
+
+        const html = `
+            <div class="cpa_it_import_dialog" style="max-height:60vh;display:flex;flex-direction:column;">
+                <div style="margin-bottom:8px;display:flex;align-items:center;gap:8px;">
+                    <label style="cursor:pointer;font-weight:bold;">
+                        <input type="checkbox" data-cpa-import-select-all checked /> ${escapeHtmlLocal(t('Select all'))}
+                    </label>
+                    <span style="color:var(--SmartThemeQuoteColor);font-size:0.85em;">
+                        (${dialogMessages.length} ${escapeHtmlLocal(t('messages'))})
+                    </span>
+                </div>
+                <div style="overflow-y:auto;flex:1;border:1px solid var(--SmartThemeBorderColor);border-radius:4px;padding:6px;">
+                    ${listHtml}
+                </div>
+            </div>`;
+
+        const importPopup = new Popup(html, POPUP_TYPE.CONFIRM, '', {
+            okButton: t('Import selected'),
+            cancelButton: t('Cancel'),
+            wider: true,
+            allowVerticalScrolling: true,
+        });
+
+        const $dialog = jQuery('.cpa_it_import_dialog');
+        $dialog.on('change', '[data-cpa-import-select-all]', function () {
+            const checked = this.checked;
+            $dialog.find('[data-cpa-import-idx]').prop('checked', checked);
+        });
+        $dialog.on('change', '[data-cpa-import-idx]', function () {
+            const allBoxes = $dialog.find('[data-cpa-import-idx]');
+            const allChecked = allBoxes.length === allBoxes.filter(':checked').length;
+            $dialog.find('[data-cpa-import-select-all]').prop('checked', allChecked);
+        });
+
+        const result = await importPopup.show();
+        if (result !== POPUP_RESULT.AFFIRMATIVE) return;
+
+        const checkedIndices = new Set();
+        $dialog.find('[data-cpa-import-idx]:checked').each(function () {
+            checkedIndices.add(Number(this.getAttribute('data-cpa-import-idx')));
+        });
+        if (checkedIndices.size === 0) {
+            try { toastr.info(t('No messages selected.')); } catch { /* ignore */ }
+            return;
+        }
+
+        const selected = dialogMessages.filter((_, i) => checkedIndices.has(i));
+
+        if (state.session._transient && state.session.messages.length === 0) {
+            state.session = createNewSession();
+            state.session._transient = false;
+        }
+
+        for (const m of selected) {
+            const role = m.is_user ? 'user' : 'assistant';
+            const at = m.send_date ? new Date(m.send_date).getTime() : Date.now();
+            state.session.messages.push(normalizeMessageShape({
+                id: makeMessageId(),
+                role,
+                content: String(m.mes || ''),
+                at: isNaN(at) ? Date.now() : at,
+            }, Date.now()));
+        }
+
+        state.session.updatedAt = Date.now();
+        await persistSession();
+        await render();
+        try { toastr.success(tf('Imported ${0} message(s).', String(checkedIndices.size))); } catch { /* ignore */ }
     }
 
     // ──────────────────────────────────────────────────────────────────
@@ -2583,6 +2685,7 @@ export async function openCpaIterationStudio(deps) {
         historyLabel: t('History'),
         newSessionLabel: t('New session'),
         clearAllLabel: t('Clear all'),
+        importChatLabel: t('Import chat'),
         sendLabel: t('Send'),
         composerPlaceholder: t('Describe what to change in the preset...'),
         referenceLabel: t('Reference preset:'),
@@ -2741,6 +2844,10 @@ export async function openCpaIterationStudio(deps) {
     $root.on('click.cpaIt', '[data-cpa-it-action="clear-history"]', async (e) => {
         e.preventDefault();
         await clearAllHistory();
+    });
+    $root.on('click.cpaIt', '[data-cpa-it-action="import-chat"]', async (e) => {
+        e.preventDefault();
+        await importFromMainChat();
     });
     $root.on('click.cpaIt', '[data-cpa-it-action="load-session"]', async (e) => {
         // The delete button is a child of the load row — stop the row's

--- a/public/scripts/extensions/completion-preset-assistant/cpa-iteration/studio.js
+++ b/public/scripts/extensions/completion-preset-assistant/cpa-iteration/studio.js
@@ -1531,19 +1531,9 @@ export async function openCpaIterationStudio(deps) {
             const readCallIds = new Set(toolResults.map(r => String(r?.tool_call_id || '')));
             const readToolCalls = toolCalls.filter(c => readCallIds.has(String(c?.id || '')));
             if (role === 'assistant' && readToolCalls.length > 0) {
-                const persistedReasoning = typeof m?.reasoning === 'string' ? m.reasoning : '';
-                const persistedReasoningBlocks = Array.isArray(m?.reasoningBlocks) && m.reasoningBlocks.length > 0
-                    ? m.reasoningBlocks
-                    : null;
-                const persistedReasoningDetails = Array.isArray(m?.reasoningDetails) && m.reasoningDetails.length > 0
-                    ? m.reasoningDetails
-                    : null;
                 messages.push({
                     role: 'assistant',
                     content,
-                    ...(persistedReasoning ? { reasoning: persistedReasoning } : {}),
-                    ...(persistedReasoningBlocks ? { reasoning_blocks: persistedReasoningBlocks } : {}),
-                    ...(persistedReasoningDetails ? { reasoning_details: persistedReasoningDetails } : {}),
                     tool_calls: readToolCalls.map(c => ({
                         id: String(c.id || ''),
                         type: 'function',

--- a/public/scripts/extensions/completion-preset-assistant/cpa-iteration/studio.js
+++ b/public/scripts/extensions/completion-preset-assistant/cpa-iteration/studio.js
@@ -956,7 +956,7 @@ export async function openCpaIterationStudio(deps) {
         const ctx = getContext();
         const chat = ctx.chat;
         if (!Array.isArray(chat) || chat.length === 0) {
-            try { toastr.warning(t('No chat is currently open.')); } catch { /* ignore */ }
+            try { toastr.warning('当前没有打开的聊天'); } catch { /* ignore */ }
             return;
         }
 
@@ -965,9 +965,11 @@ export async function openCpaIterationStudio(deps) {
             .filter(m => !m.is_system);
 
         if (dialogMessages.length === 0) {
-            try { toastr.warning(t('The current chat has no user or character messages to import.')); } catch { /* ignore */ }
+            try { toastr.warning('当前聊天没有可导入的消息'); } catch { /* ignore */ }
             return;
         }
+
+        const selectedSet = new Set(dialogMessages.map((_, i) => i));
 
         const listHtml = dialogMessages.map((m, i) => {
             const role = m.is_user ? 'user' : 'assistant';
@@ -983,10 +985,10 @@ export async function openCpaIterationStudio(deps) {
             <div class="cpa_it_import_dialog" style="max-height:60vh;display:flex;flex-direction:column;">
                 <div style="margin-bottom:8px;display:flex;align-items:center;gap:8px;">
                     <label style="cursor:pointer;font-weight:bold;">
-                        <input type="checkbox" data-cpa-import-select-all checked /> ${escapeHtmlLocal(t('Select all'))}
+                        <input type="checkbox" data-cpa-import-select-all checked /> 全选
                     </label>
                     <span style="color:var(--SmartThemeQuoteColor);font-size:0.85em;">
-                        (${dialogMessages.length} ${escapeHtmlLocal(t('messages'))})
+                        (共 ${dialogMessages.length} 条消息)
                     </span>
                 </div>
                 <div style="overflow-y:auto;flex:1;border:1px solid var(--SmartThemeBorderColor);border-radius:4px;padding:6px;">
@@ -995,36 +997,39 @@ export async function openCpaIterationStudio(deps) {
             </div>`;
 
         const importPopup = new Popup(html, POPUP_TYPE.CONFIRM, '', {
-            okButton: t('Import selected'),
-            cancelButton: t('Cancel'),
+            okButton: '导入选中',
+            cancelButton: '取消',
             wider: true,
             allowVerticalScrolling: true,
         });
 
-        const $dialog = jQuery('.cpa_it_import_dialog');
-        $dialog.on('change', '[data-cpa-import-select-all]', function () {
+        jQuery(document).on('change.cpaImport', '[data-cpa-import-select-all]', function () {
             const checked = this.checked;
-            $dialog.find('[data-cpa-import-idx]').prop('checked', checked);
+            jQuery('[data-cpa-import-idx]').prop('checked', checked);
+            if (checked) {
+                dialogMessages.forEach((_, i) => selectedSet.add(i));
+            } else {
+                selectedSet.clear();
+            }
         });
-        $dialog.on('change', '[data-cpa-import-idx]', function () {
-            const allBoxes = $dialog.find('[data-cpa-import-idx]');
+        jQuery(document).on('change.cpaImport', '[data-cpa-import-idx]', function () {
+            const idx = Number(this.getAttribute('data-cpa-import-idx'));
+            if (this.checked) selectedSet.add(idx); else selectedSet.delete(idx);
+            const allBoxes = jQuery('[data-cpa-import-idx]');
             const allChecked = allBoxes.length === allBoxes.filter(':checked').length;
-            $dialog.find('[data-cpa-import-select-all]').prop('checked', allChecked);
+            jQuery('[data-cpa-import-select-all]').prop('checked', allChecked);
         });
 
         const result = await importPopup.show();
-        if (result !== POPUP_RESULT.AFFIRMATIVE) return;
+        jQuery(document).off('.cpaImport');
 
-        const checkedIndices = new Set();
-        $dialog.find('[data-cpa-import-idx]:checked').each(function () {
-            checkedIndices.add(Number(this.getAttribute('data-cpa-import-idx')));
-        });
-        if (checkedIndices.size === 0) {
-            try { toastr.info(t('No messages selected.')); } catch { /* ignore */ }
+        if (result !== POPUP_RESULT.AFFIRMATIVE) return;
+        if (selectedSet.size === 0) {
+            try { toastr.info('没有选中任何消息'); } catch { /* ignore */ }
             return;
         }
 
-        const selected = dialogMessages.filter((_, i) => checkedIndices.has(i));
+        const selected = dialogMessages.filter((_, i) => selectedSet.has(i));
 
         if (state.session._transient && state.session.messages.length === 0) {
             state.session = createNewSession();
@@ -1045,7 +1050,7 @@ export async function openCpaIterationStudio(deps) {
         state.session.updatedAt = Date.now();
         await persistSession();
         await render();
-        try { toastr.success(tf('Imported ${0} message(s).', String(checkedIndices.size))); } catch { /* ignore */ }
+        try { toastr.success(`已导入 ${selectedSet.size} 条消息`); } catch { /* ignore */ }
     }
 
     // ──────────────────────────────────────────────────────────────────
@@ -2685,7 +2690,7 @@ export async function openCpaIterationStudio(deps) {
         historyLabel: t('History'),
         newSessionLabel: t('New session'),
         clearAllLabel: t('Clear all'),
-        importChatLabel: t('Import chat'),
+        importChatLabel: t('导入对话'),
         sendLabel: t('Send'),
         composerPlaceholder: t('Describe what to change in the preset...'),
         referenceLabel: t('Reference preset:'),

--- a/public/scripts/extensions/completion-preset-assistant/cpa-iteration/studio.js
+++ b/public/scripts/extensions/completion-preset-assistant/cpa-iteration/studio.js
@@ -1002,26 +1002,27 @@ export async function openCpaIterationStudio(deps) {
             wider: true,
             allowVerticalScrolling: true,
         });
+        const $dlg = jQuery(importPopup.dlg);
 
-        jQuery(document).on('change.cpaImport', '[data-cpa-import-select-all]', function () {
+        $dlg.on('change.cpaImport', '[data-cpa-import-select-all]', function () {
             const checked = this.checked;
-            jQuery('[data-cpa-import-idx]').prop('checked', checked);
+            $dlg.find('[data-cpa-import-idx]').prop('checked', checked);
             if (checked) {
                 dialogMessages.forEach((_, i) => selectedSet.add(i));
             } else {
                 selectedSet.clear();
             }
         });
-        jQuery(document).on('change.cpaImport', '[data-cpa-import-idx]', function () {
+        $dlg.on('change.cpaImport', '[data-cpa-import-idx]', function () {
             const idx = Number(this.getAttribute('data-cpa-import-idx'));
             if (this.checked) selectedSet.add(idx); else selectedSet.delete(idx);
-            const allBoxes = jQuery('[data-cpa-import-idx]');
+            const allBoxes = $dlg.find('[data-cpa-import-idx]');
             const allChecked = allBoxes.length === allBoxes.filter(':checked').length;
-            jQuery('[data-cpa-import-select-all]').prop('checked', allChecked);
+            $dlg.find('[data-cpa-import-select-all]').prop('checked', allChecked);
         });
 
         const result = await importPopup.show();
-        jQuery(document).off('.cpaImport');
+        $dlg.off('.cpaImport');
 
         if (result !== POPUP_RESULT.AFFIRMATIVE) return;
         if (selectedSet.size === 0) {

--- a/public/scripts/extensions/memory-graph/schema-iteration/studio.js
+++ b/public/scripts/extensions/memory-graph/schema-iteration/studio.js
@@ -1666,19 +1666,9 @@ export async function openSchemaIterationStudio(deps) {
                             arguments: JSON.stringify(tc?.args || {}),
                         },
                     }));
-                    const persistedReasoning = typeof m?.reasoning === 'string' ? m.reasoning : '';
-                    const persistedReasoningBlocks = Array.isArray(m?.reasoningBlocks) && m.reasoningBlocks.length > 0
-                        ? m.reasoningBlocks
-                        : null;
-                    const persistedReasoningDetails = Array.isArray(m?.reasoningDetails) && m.reasoningDetails.length > 0
-                        ? m.reasoningDetails
-                        : null;
                     messages.push({
                         role: 'assistant',
                         content,
-                        ...(persistedReasoning ? { reasoning: persistedReasoning } : {}),
-                        ...(persistedReasoningBlocks ? { reasoning_blocks: persistedReasoningBlocks } : {}),
-                        ...(persistedReasoningDetails ? { reasoning_details: persistedReasoningDetails } : {}),
                         tool_calls: toolCallsForHistory,
                     });
                     const resultById = new Map();

--- a/public/scripts/extensions/orchestrator/iter-studio/studio.js
+++ b/public/scripts/extensions/orchestrator/iter-studio/studio.js
@@ -2241,19 +2241,9 @@ export async function openOrchestratorIterationStudio(deps) {
                         arguments: JSON.stringify(tc?.args || {}),
                     },
                 }));
-                const persistedReasoning = typeof m?.reasoning === 'string' ? m.reasoning : '';
-                const persistedReasoningBlocks = Array.isArray(m?.reasoningBlocks) && m.reasoningBlocks.length > 0
-                    ? m.reasoningBlocks
-                    : null;
-                const persistedReasoningDetails = Array.isArray(m?.reasoningDetails) && m.reasoningDetails.length > 0
-                    ? m.reasoningDetails
-                    : null;
                 messages.push({
                     role: 'assistant',
                     content,
-                    ...(persistedReasoning ? { reasoning: persistedReasoning } : {}),
-                    ...(persistedReasoningBlocks ? { reasoning_blocks: persistedReasoningBlocks } : {}),
-                    ...(persistedReasoningDetails ? { reasoning_details: persistedReasoningDetails } : {}),
                     tool_calls: toolCallsForHistory,
                 });
                 const resultById = new Map();

--- a/public/scripts/iteration-library/ui/message.js
+++ b/public/scripts/iteration-library/ui/message.js
@@ -82,6 +82,19 @@ export function renderMessageCard(message, opts = {}) {
     const content = String(message.content || '');
     const bodyHtml = renderMd ? renderMd(content) : escapeHtml(content).replace(/\n/g, '<br>');
 
+    // Reasoning / thinking chain — display only, never sent back to API
+    const reasoningText = String(message.reasoning || '');
+    let reasoningHtml = '';
+    if (reasoningText.length > 0) {
+        const reasoningBody = renderMd
+            ? renderMd(reasoningText)
+            : escapeHtml(reasoningText).replace(/\n/g, '<br>');
+        reasoningHtml = `<details class="luker_lib_reasoning_details">
+            <summary class="luker_lib_reasoning_summary">${escapeHtml(i18n('Thinking'))}</summary>
+            <div class="luker_lib_reasoning_body">${reasoningBody}</div>
+        </details>`;
+    }
+
     const toolCalls = Array.isArray(message.toolCalls) ? message.toolCalls : [];
     const toolResults = Array.isArray(message.toolResults) ? message.toolResults : [];
     const resultById = new Map();
@@ -98,10 +111,11 @@ export function renderMessageCard(message, opts = {}) {
     // when content + tools + edits are all empty (e.g. an old assistant
     // turn whose tools were stripped on regen).
     const hasContent = content.length > 0;
+    const hasReasoning = reasoningText.length > 0;
     const hasTools = toolCalls.length > 0 || toolResults.length > 0;
     const hasEdits = edits.length > 0;
     const hasStatus = Boolean(message.appliedAt) || Boolean(message.rolledBackAt);
-    if (!hasContent && !hasTools && !hasEdits && !hasStatus) {
+    if (!hasContent && !hasReasoning && !hasTools && !hasEdits && !hasStatus) {
         return '';
     }
 
@@ -149,6 +163,7 @@ export function renderMessageCard(message, opts = {}) {
         : '';
 
     return `<div class="luker_lib_message luker_lib_message_assistant" data-luker-lib-msg-id="${escapeHtmlAttr(msgId)}">
+        ${reasoningHtml}
         ${bodyHtml}
         ${readOnlyHint}
         ${toolsHtml}

--- a/public/scripts/iteration-library/ui/styles.css
+++ b/public/scripts/iteration-library/ui/styles.css
@@ -231,3 +231,32 @@
 }
 .luker_lib_apply_applied     { color: var(--SmartThemeQuoteColor, #4a90e2); }
 .luker_lib_apply_rolledback  { opacity: 0.7; font-style: italic; }
+
+/* ── reasoning / thinking chain ───────────────────────────────── */
+.luker_lib_reasoning_details {
+    margin-bottom: 8px;
+    border-left: 2px solid var(--reasoning-body-color, color-mix(in oklab, var(--SmartThemeBodyColor, #ccc) 50%, transparent));
+    border-radius: 2px;
+    padding-left: 12px;
+}
+.luker_lib_reasoning_summary {
+    cursor: pointer;
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: 10px;
+    background: color-mix(in oklab, var(--SmartThemeBodyColor, #ccc) 12%, transparent);
+    font-size: 0.85em;
+    opacity: 0.75;
+    user-select: none;
+}
+.luker_lib_reasoning_summary:hover {
+    opacity: 1;
+}
+.luker_lib_reasoning_body {
+    margin-top: 6px;
+    font-size: 0.9em;
+    opacity: 0.7;
+    line-height: 1.5;
+}
+.luker_lib_reasoning_body p:first-child { margin-top: 0; }
+.luker_lib_reasoning_body p:last-child  { margin-bottom: 0; }

--- a/public/scripts/iteration-library/ui/toolcall.js
+++ b/public/scripts/iteration-library/ui/toolcall.js
@@ -1,3 +1,5 @@
+import { renderInlineTextDiffHtml, ensureStylesheetInjected } from '../text-diff.js';
+
 /**
  * Render one tool call as a CardApp-Studio-style one-liner with optional
  * `<details>` expansion that shows friendly per-arg breakdown (not raw JSON).
@@ -116,7 +118,63 @@ function renderFieldRows(obj) {
     return rowLines.join('\n');
 }
 
+/**
+ * Detect string-edit tool args (replace/delete/insert) and render a
+ * proper red/green diff instead of dumping raw oldString/newString text.
+ * Returns HTML string if a diff pattern was found, empty string otherwise.
+ */
+function tryRenderArgsDiff(args, i18n) {
+    if (!args || typeof args !== 'object') return '';
+
+    const diffTextKeys = new Set([
+        'oldString', 'newString', 'find', 'after_text', 'insert_text', 'replaceAll', 'expected_count',
+    ]);
+
+    let beforeText = null;
+    let afterText = null;
+
+    if (typeof args.oldString === 'string' && typeof args.newString === 'string') {
+        beforeText = args.oldString;
+        afterText = args.newString;
+    } else if (typeof args.find === 'string' && !('newString' in args)) {
+        beforeText = args.find;
+        afterText = '';
+    } else if (typeof args.after_text === 'string' && typeof args.insert_text === 'string') {
+        beforeText = args.after_text;
+        afterText = args.after_text + args.insert_text;
+    } else {
+        return '';
+    }
+
+    const metaArgs = {};
+    for (const k of Object.keys(args)) {
+        if (!diffTextKeys.has(k)) metaArgs[k] = args[k];
+    }
+    const metaRows = renderFieldRows(metaArgs);
+    const metaHtml = metaRows
+        ? `<div class="luker_lib_toolcall_arg_rows">${metaRows}</div>`
+        : '';
+
+    ensureStylesheetInjected();
+    const diffBlock = renderInlineTextDiffHtml(beforeText, afterText, {
+        i18n,
+        forceOpen: false,
+        expandAffordance: true,
+    });
+
+    return [
+        `<details class="luker_lib_toolcall_details" open>`,
+        `<summary>${escapeHtml(i18n('Arguments'))}</summary>`,
+        metaHtml,
+        diffBlock,
+        `</details>`,
+    ].join('\n');
+}
+
 function renderArgsDetails(args, i18n) {
+    const diffHtml = tryRenderArgsDiff(args, i18n);
+    if (diffHtml) return diffHtml;
+
     const rows = renderFieldRows(args);
     if (!rows) return '';
     return [

--- a/public/scripts/lib/iter-tool-calling.js
+++ b/public/scripts/lib/iter-tool-calling.js
@@ -537,7 +537,7 @@ export function buildRejectedToolResults(toolCalls = [], summaryText = '') {
     })).filter(item => item.tool_call_id);
 }
 
-export function appendStandardToolRoundMessages(targetMessages, executedCalls, assistantText = '', { reasoning = '', reasoningBlocks = null, reasoningDetails = null } = {}) {
+export function appendStandardToolRoundMessages(targetMessages, executedCalls, assistantText = '') {
     if (!Array.isArray(targetMessages) || !Array.isArray(executedCalls) || executedCalls.length === 0) {
         return;
     }
@@ -561,16 +561,9 @@ export function appendStandardToolRoundMessages(targetMessages, executedCalls, a
         return;
     }
 
-    const trimmedReasoning = typeof reasoning === 'string' ? reasoning : '';
-    const trimmedBlocks = Array.isArray(reasoningBlocks) && reasoningBlocks.length > 0 ? reasoningBlocks : null;
-    const trimmedDetails = Array.isArray(reasoningDetails) && reasoningDetails.length > 0 ? reasoningDetails : null;
-
     targetMessages.push({
         role: 'assistant',
         content: String(assistantText || ''),
-        ...(trimmedReasoning ? { reasoning: trimmedReasoning } : {}),
-        ...(trimmedBlocks ? { reasoning_blocks: trimmedBlocks } : {}),
-        ...(trimmedDetails ? { reasoning_details: trimmedDetails } : {}),
         tool_calls: toolCalls.map(({ _result, ...toolCall }) => toolCall),
     });
 


### PR DESCRIPTION
## 问题

CPA 迭代工作台的会话无法持久化——关闭弹窗再打开，始终显示"没有已保存的会话"。

## 原因

`session-store.js` 的 `readStore()` 直接把 `ctx.presets.state.get()` 的返回值当 store 用，但该 API 返回的是 `{ ok, state }` 信封，真正数据在 `.state` 里。

信封上没有 `.sessions`，所以 `Array.isArray(store.sessions)` 永远 false，每次都返回空默认值。写入端正常（`updatePresetState` 内部用 `getPresetStateRaw()` 做了解包），所以 sidecar 文件里数据是对的，只是读取端解包缺失。

## 修复

在 `readStore()` 中正确解包信封：

```js
const result = await ctx.presets.state.get(SESSION_NAMESPACE, { target: ref });
const store = result?.ok ? result.state : null;