### PR TITLE
feat(iteration-library): 迭代工作台消息卡显示思维链feat(iteration-library): display thinking chain in iteration studio m…

### DIFF
--- a/public/scripts/iteration-library/ui/message.js
+++ b/public/scripts/iteration-library/ui/message.js
@@ -82,6 +82,19 @@ export function renderMessageCard(message, opts = {}) {
     const content = String(message.content || '');
     const bodyHtml = renderMd ? renderMd(content) : escapeHtml(content).replace(/\n/g, '<br>');
 
+    // Reasoning / thinking chain — display only, never sent back to API
+    const reasoningText = String(message.reasoning || '');
+    let reasoningHtml = '';
+    if (reasoningText.length > 0) {
+        const reasoningBody = renderMd
+            ? renderMd(reasoningText)
+            : escapeHtml(reasoningText).replace(/\n/g, '<br>');
+        reasoningHtml = `<details class="luker_lib_reasoning_details">
+            <summary class="luker_lib_reasoning_summary">${escapeHtml(i18n('Thinking'))}</summary>
+            <div class="luker_lib_reasoning_body">${reasoningBody}</div>
+        </details>`;
+    }
+
     const toolCalls = Array.isArray(message.toolCalls) ? message.toolCalls : [];
     const toolResults = Array.isArray(message.toolResults) ? message.toolResults : [];
     const resultById = new Map();
@@ -98,10 +111,11 @@ export function renderMessageCard(message, opts = {}) {
     // when content + tools + edits are all empty (e.g. an old assistant
     // turn whose tools were stripped on regen).
     const hasContent = content.length > 0;
+    const hasReasoning = reasoningText.length > 0;
     const hasTools = toolCalls.length > 0 || toolResults.length > 0;
     const hasEdits = edits.length > 0;
     const hasStatus = Boolean(message.appliedAt) || Boolean(message.rolledBackAt);
-    if (!hasContent && !hasTools && !hasEdits && !hasStatus) {
+    if (!hasContent && !hasReasoning && !hasTools && !hasEdits && !hasStatus) {
         return '';
     }
 
@@ -149,6 +163,7 @@ export function renderMessageCard(message, opts = {}) {
         : '';
 
     return `<div class="luker_lib_message luker_lib_message_assistant" data-luker-lib-msg-id="${escapeHtmlAttr(msgId)}">
+        ${reasoningHtml}
         ${bodyHtml}
         ${readOnlyHint}
         ${toolsHtml}

--- a/public/scripts/iteration-library/ui/styles.css
+++ b/public/scripts/iteration-library/ui/styles.css
@@ -231,3 +231,32 @@
 }
 .luker_lib_apply_applied     { color: var(--SmartThemeQuoteColor, #4a90e2); }
 .luker_lib_apply_rolledback  { opacity: 0.7; font-style: italic; }
+
+/* ── reasoning / thinking chain ───────────────────────────────── */
+.luker_lib_reasoning_details {
+    margin-bottom: 8px;
+    border-left: 2px solid var(--reasoning-body-color, color-mix(in oklab, var(--SmartThemeBodyColor, #ccc) 50%, transparent));
+    border-radius: 2px;
+    padding-left: 12px;
+}
+.luker_lib_reasoning_summary {
+    cursor: pointer;
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: 10px;
+    background: color-mix(in oklab, var(--SmartThemeBodyColor, #ccc) 12%, transparent);
+    font-size: 0.85em;
+    opacity: 0.75;
+    user-select: none;
+}
+.luker_lib_reasoning_summary:hover {
+    opacity: 1;
+}
+.luker_lib_reasoning_body {
+    margin-top: 6px;
+    font-size: 0.9em;
+    opacity: 0.7;
+    line-height: 1.5;
+}
+.luker_lib_reasoning_body p:first-child { margin-top: 0; }
+.luker_lib_reasoning_body p:last-child  { margin-bottom: 0; }


### PR DESCRIPTION
## 功能

助手消息卡在正文上方渲染一个可折叠的「思考块」,展示模型的
reasoning/thinking 内容。纯展示层 —— 读取 message.reasoning,
不参与 API 回传,与您现有的思维链重放逻辑完全独立、无冲突。

样式与主聊天的思考显示保持一致;"Thinking" 的 zh-cn/zh-tw 翻译
仓库里已存在,无需新增。

## 相对 #16 的修正

按您的建议从 #16 拆出单独提交。您提到它与另一个工作(停止重放
reasoning)冲突 —— 那个提交我已在自己仓库撤销(您的按渠道回传
实现是对的),本功能单独使用。

## 验证

- 有/无 reasoning 的渲染、纯 reasoning 消息不被空卡过滤
- reasoning 内容经 escapeHtml 转义(XSS 防护)