### PR TITLE
fix(memory-graph): stop the visible-message-window script from blanking memory input

### DIFF
--- a/public/scripts/extensions/regex/engine.js
+++ b/public/scripts/extensions/regex/engine.js
@@ -820,9 +820,9 @@ function sanitizeRegexMacro(x) {
  * @param {regex_placement} placement The placement of the string
  * @param {RegexParams} params The parameters to use for the regex script
  * @returns {string} The regexed string
- * @typedef {{characterOverride?: string, isMarkdown?: boolean, isPrompt?: boolean, isPluginPrompt?: boolean, isEdit?: boolean, depth?: number }} RegexParams The parameters to use for the regex script
+ * @typedef {{characterOverride?: string, isMarkdown?: boolean, isPrompt?: boolean, isPluginPrompt?: boolean, isEdit?: boolean, depth?: number, userScriptsOnly?: boolean }} RegexParams The parameters to use for the regex script
  */
-export function getRegexedString(rawString, placement, { characterOverride, isMarkdown, isPrompt, isPluginPrompt, isEdit, depth } = {}) {
+export function getRegexedString(rawString, placement, { characterOverride, isMarkdown, isPrompt, isPluginPrompt, isEdit, depth, userScriptsOnly } = {}) {
     // WTF have you passed me?
     if (typeof rawString !== 'string') {
         console.warn('getRegexedString: rawString is not a string. Returning empty string.');
@@ -837,6 +837,16 @@ export function getRegexedString(rawString, placement, { characterOverride, isMa
     const allRegex = getRegexScripts({ allowedOnly: true });
     allRegex.forEach((script, index) => {
         if (!script || typeof script !== 'object') {
+            return;
+        }
+
+        // Engine-managed runtime scripts are code-generated context plumbing,
+        // not user-authored transforms. A consumer that reads chat text to
+        // feed its OWN LLM request wants the user's rules without the
+        // plumbing — otherwise a provider that trims the main model's view of
+        // history also trims the input of whatever is supposed to summarize
+        // that history.
+        if (userScriptsOnly && script.__runtime_owner) {
             return;
         }
 

--- a/public/scripts/lib/chat-regex.js
+++ b/public/scripts/lib/chat-regex.js
@@ -27,6 +27,20 @@
  * last non-system message is depth 0. This lets a script authored with
  * `maxDepth: 4` do the same thing here that it does in Generate().
  *
+ * User-authored only (`userScriptsOnly: true`):
+ *   Engine-managed runtime providers are skipped. The one in tree is
+ *   memory-graph's "Memory Graph Visible Message Window"
+ *   (`/[\s\S]*&#47;g` -> '', `promptOnly`, `minDepth: llmVisibleRecentMessages`),
+ *   which exists to hide old turns from the MAIN model because memory
+ *   covers them. Without the flag it also fires here — at real depth,
+ *   with `isPrompt: true` — so every message at or beyond the window
+ *   arrives blank at the extractor that is supposed to summarize it.
+ *   Defaults make that reachable in normal use (window 5 vs a batch
+ *   spanning ~6 messages) and total for Rebuild / Fill, which walk the
+ *   whole history. Depth cannot express the exclusion: `undefined`
+ *   disables the min/maxDepth gate entirely and makes the blanking
+ *   unconditional.
+ *
  * Regex engine access:
  *   We consume the regex primitives through `Luker.getContext().regex`
  *   (three-layer API). Direct `import` from
@@ -129,7 +143,7 @@ export function regexChatMessageForAgent(message, depth) {
     const api = getRegexApi();
     if (!api) return raw;
     const placement = message?.is_user ? api.placement.USER_INPUT : api.placement.AI_OUTPUT;
-    return api.applyRegex(raw, placement, { isPrompt: true, depth });
+    return api.applyRegex(raw, placement, { isPrompt: true, depth, userScriptsOnly: true });
 }
 
 /**

--- a/tests/lib/chat-regex-user-scripts-only.test.js
+++ b/tests/lib/chat-regex-user-scripts-only.test.js
@@ -1,0 +1,80 @@
+/**
+ * `regexChatMessageForAgent` must ask the engine for user-authored scripts
+ * only.
+ *
+ * Without that, memory-graph's own managed "Memory Graph Visible Message
+ * Window" provider (findRegex `/[\s\S]*​/g` -> '', promptOnly,
+ * minDepth: llmVisibleRecentMessages) fires on the chat text memory-graph
+ * feeds to its OWN extractor: the script is registered globally, runs at the
+ * real chat depth this function passes, and matches on `isPrompt: true`. Every
+ * message at or beyond the visible window then arrives blank at the extractor
+ * that is supposed to summarize it.
+ *
+ * Depth cannot express the exclusion — passing `undefined` skips the
+ * min/maxDepth gate entirely (engine.js: `if (typeof depth === 'number')`),
+ * which makes the blanking unconditional instead of removing it.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals';
+
+const { regexChatMessageForAgent, __resetRegexApiCacheForTests } =
+    await import('../../public/scripts/lib/chat-regex.js');
+
+const PLACEMENT = { USER_INPUT: 1, AI_OUTPUT: 2 };
+
+let applyRegex;
+let previousLuker;
+
+beforeEach(() => {
+    previousLuker = globalThis.Luker;
+    applyRegex = jest.fn((text) => text);
+    globalThis.Luker = {
+        getContext: () => ({ regex: { applyRegex, placement: PLACEMENT } }),
+    };
+    __resetRegexApiCacheForTests();
+});
+
+afterEach(() => {
+    globalThis.Luker = previousLuker;
+    __resetRegexApiCacheForTests();
+});
+
+describe('regexChatMessageForAgent: user-authored scripts only', () => {
+    test('requests userScriptsOnly so managed runtime providers are skipped', () => {
+        regexChatMessageForAgent({ mes: 'Alice met Bob at the gate.', is_user: false }, 12);
+        expect(applyRegex).toHaveBeenCalledWith(
+            'Alice met Bob at the gate.',
+            PLACEMENT.AI_OUTPUT,
+            expect.objectContaining({ userScriptsOnly: true }),
+        );
+    });
+
+    test('still passes real depth and prompt scope for user-authored rules', () => {
+        regexChatMessageForAgent({ mes: 'body', is_user: true }, 4);
+        expect(applyRegex).toHaveBeenCalledWith(
+            'body',
+            PLACEMENT.USER_INPUT,
+            expect.objectContaining({ isPrompt: true, depth: 4 }),
+        );
+    });
+
+    test('an old turn is not blanked once managed providers are excluded', () => {
+        // Stand-in for the engine: the managed window script blanks anything at
+        // depth >= 5 unless the caller opted out of runtime-provider scripts.
+        applyRegex.mockImplementation((text, _placement, params) => {
+            const managedWouldFire = typeof params?.depth !== 'number' || params.depth >= 5;
+            if (managedWouldFire && !params?.userScriptsOnly) {
+                return '';
+            }
+            return text;
+        });
+        expect(regexChatMessageForAgent({ mes: 'turn 40 prose', is_user: false }, 40))
+            .toBe('turn 40 prose');
+    });
+
+    test('degrades to raw text when the regex API is unreachable', () => {
+        globalThis.Luker = undefined;
+        __resetRegexApiCacheForTests();
+        expect(regexChatMessageForAgent({ mes: 'raw', is_user: false }, 0)).toBe('raw');
+    });
+});


### PR DESCRIPTION
## 问题

`regexChatMessageForAgent` 的模块文档写的是「apply **user-authored** regex scripts to chat text that will be fed to plugin-driven LLM requests」，但它实际上也会套用引擎托管的 runtime provider 脚本。而全仓库唯一的 runtime provider，正是 memory-graph 自己注册的 `Memory Graph Visible Message Window`：

```
findRegex   /[\s\S]*/g  ->  replaceString ''
promptOnly  true
minDepth    llmVisibleRecentMessages   (默认 5)
placement   [USER_INPUT, AI_OUTPUT]
```

这个脚本的用途是**对主模型**隐藏较老的楼层（因为那些内容已由 memory 覆盖）。但没有任何东西把它挡在 memory-graph 自己的读取路径之外：

| 环节 | 位置 |
|---|---|
| 抽取批次按真实 depth 组装 | `main.js` `buildRoleSplitChatMessages` → `computeDepthsFromEnd` |
| 传 `isPrompt: true` + 真实 depth | `chat-regex.js` `regexChatMessageForAgent` |
| `promptOnly && isPrompt` 命中 | `engine.js:854` |
| `depth < minDepth` 才跳过，depth ≥ 5 不跳过 | `engine.js:868` |
| placement 命中 → 执行 | `engine.js:879` |
| 结果 | 整条消息被替换为 `''` |

**后果**：深度 ≥ `llmVisibleRecentMessages` 的聊天消息，喂给抽取时是空的。

默认配置下就会触发——窗口默认 5，而一个批次是 `extractBatchTurns: 1` + `extractContextTurns: 2`，约 6 条消息（user/assistant 交替），最老的几条已经落在窗口外。**Rebuild / 增量补全**遍历全历史，则几乎全部为空，等于用空白输入重建记忆图。

## 修复

`getRegexedString` 增加 `userScriptsOnly` 参数，跳过被 `collectRuntimeRegexScripts` 打上 `__runtime_owner` 标记的脚本；`regexChatMessageForAgent` 设置该参数。用户自己写的正则仍按真实 depth 套用，与主管线的一致性不变。

选择这个方案而不是调 depth 的原因：`depth: undefined` 会**完全跳过** min/maxDepth 判断（`engine.js:867` 的 `if (typeof depth === 'number')`），结果是让清空变成无条件的，比现状更糟；`depth: 0` 又会让用户自己写的 `minDepth` 规则全部失效。

## 测试

新增 `tests/lib/chat-regex-user-scripts-only.test.js`（4 个用例，覆盖边界契约）。

引擎侧的过滤没有单测：`engine.js` 在当前 jest 配置下无法导入（先撞 `document is not defined`，改 jsdom 后撞 `fflate` 的 ESM 解析），仓库里所有现存测试都是 mock 掉它的。所以我测的是 `regexChatMessageForAgent` 这一层的契约。如果你希望补引擎层的覆盖，可能需要走 e2e。

本分支上 `memory-graph` / `lib` / `character-presets` 共 99 个套件：97 通过、971/971 个测试通过。另外 2 个套件（`character-presets/ctx-dispatch`、`ctx-selected-live-state`）在模块加载阶段就失败，原因是 `st-context.js:156` 从 `world-info.js` 导入了并不存在的 `deleteWorldInfo`——这是本分支之前就有的问题，与本 PR 无关。
